### PR TITLE
Improve contrast and use rounded-square checkboxes

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,10 +6,10 @@
   --color-bg-input: #111111;
   --color-bg-hover: #252525;
   --color-bg-surface: #141414;
-  --color-text-primary: #fafafa;
-  --color-text-secondary: #888888;
-  --color-text-muted: #555555;
-  --color-border: #2a2a2a;
+  --color-text-primary: #eeeeee;
+  --color-text-secondary: #a0a0a0;
+  --color-text-muted: #737373;
+  --color-border: #333333;
   --color-accent-green: #22c55e;
   --color-accent-red: #ef4444;
   --color-accent-amber: #f59e0b;

--- a/frontend/src/components/task-item.tsx
+++ b/frontend/src/components/task-item.tsx
@@ -163,7 +163,7 @@ export function TaskItem({ task, domains, onMutate }: TaskItemProps) {
           onClick={handleComplete}
           disabled={isComplete}
           className={cn(
-            "shrink-0 h-5 w-5 rounded-full border-2 transition-colors flex items-center justify-center",
+            "shrink-0 h-5 w-5 rounded border-2 transition-colors flex items-center justify-center",
             isComplete
               ? "border-accent-green bg-accent-green"
               : "border-border hover:border-text-secondary",
@@ -312,7 +312,7 @@ export function TaskItem({ task, domains, onMutate }: TaskItemProps) {
             >
               <span
                 className={cn(
-                  "h-4 w-4 rounded-full border-2 flex items-center justify-center shrink-0",
+                  "h-4 w-4 rounded border-2 flex items-center justify-center shrink-0",
                   child.status === "complete"
                     ? "border-accent-green bg-accent-green"
                     : "border-border",
@@ -329,7 +329,7 @@ export function TaskItem({ task, domains, onMutate }: TaskItemProps) {
           ))}
           {isAddingSubtask && (
             <div className="flex items-center gap-2 py-1.5">
-              <span className="h-4 w-4 rounded-full border-2 border-border shrink-0" />
+              <span className="h-4 w-4 rounded border-2 border-border shrink-0" />
               <input
                 ref={subtaskInputRef}
                 value={subtaskText}


### PR DESCRIPTION
## Summary

- **Color contrast (closes #15):** Updated all 4 text/border theme tokens for WCAG AA readability. `text-muted` was at 2.7:1 ratio (failing) — now at ~4.0:1. Research based on Radix Colors, GitHub Primer, and Tailwind neutral scale.
- **Checkbox shape (closes #13):** Task checkboxes are now rounded squares (`rounded`) instead of circles. Domain dots remain circular — shape encodes meaning (square = completion, circle = domain).

## Changes

| Token | Before | After | Contrast vs `#0a0a0a` |
|---|---|---|---|
| `text-primary` | `#fafafa` | `#eeeeee` | ~17.4:1 |
| `text-secondary` | `#888888` | `#a0a0a0` | ~7.3:1 |
| `text-muted` | `#555555` | `#737373` | ~4.0:1 |
| `border` | `#2a2a2a` | `#333333` | ~1.8:1 |

## Test plan

- [ ] Verify muted text (domain filters, completed headers, age badges) is readable on both `bg-root` and `bg-card`
- [ ] Verify checkboxes render as rounded squares, domain dots remain circles
- [ ] Confirm completed task checkboxes show green fill with checkmark correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)