### PR TITLE
Fix triage UI stuck after acting on last task

### DIFF
--- a/frontend/src/app/(app)/triage/page.tsx
+++ b/frontend/src/app/(app)/triage/page.tsx
@@ -25,8 +25,8 @@ export default function TriagePage() {
       .catch(() => setLoading(false));
   }, [router]);
 
-  function handleAction(result: { triage_complete: boolean }) {
-    if (result.triage_complete || !queue || currentIndex >= queue.tasks.length - 1) {
+  function handleAction(result: { triage_complete: boolean; remaining: number }) {
+    if (result.triage_complete || result.remaining === 0 || !queue || currentIndex >= queue.tasks.length - 1) {
       router.replace("/today");
       return;
     }

--- a/frontend/src/components/triage-card.tsx
+++ b/frontend/src/components/triage-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { Task, TriageAction, BucketType } from "@/lib/api-types";
+import type { Task, TriageAction, TriageResult, BucketType } from "@/lib/api-types";
 import { submitTriage } from "@/lib/api";
 import { DomainBadge } from "@/components/domain-badge";
 import { formatAge, cn } from "@/lib/utils";
@@ -9,7 +9,7 @@ import { formatAge, cn } from "@/lib/utils";
 interface TriageCardProps {
   task: Task;
   progress: { current: number; total: number };
-  onAction: (result: { triage_complete: boolean }) => void;
+  onAction: (result: TriageResult) => void;
 }
 
 export function TriageCard({ task, progress, onAction }: TriageCardProps) {
@@ -28,8 +28,13 @@ export function TriageCard({ task, progress, onAction }: TriageCardProps) {
     if (rewriteMode && rewriteText.trim() !== task.text) {
       body.rewritten_text = rewriteText.trim();
     }
-    const result = await submitTriage(task.id, body);
-    onAction(result);
+    try {
+      const result = await submitTriage(task.id, body);
+      onAction(result);
+    } catch (err) {
+      console.error("Triage action failed:", err);
+      setLoading(false);
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- Fixes #21: After acting on the last triage task (e.g., Kill on task 7/7), the UI would sometimes get permanently stuck
- Root cause: `TriageCard.handleAction` had no `try/catch` — if `submitTriage` threw, `onAction` was never called and `loading` stayed `true` forever (all buttons disabled)
- Also added `result.remaining === 0` check in the page's handler as a belt-and-suspenders safeguard

## Test plan
- [ ] Complete a full triage session, acting on every task
- [ ] Verify the UI navigates to /today after the last task
- [ ] Kill network connectivity mid-triage to verify the card recovers (buttons re-enable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)