### PR TITLE
Move task input above task list

### DIFF
--- a/frontend/src/app/(app)/bucket/[b]/page.tsx
+++ b/frontend/src/app/(app)/bucket/[b]/page.tsx
@@ -77,6 +77,9 @@ export default function BucketPage() {
         <span className="text-xs text-text-muted">{pending.length} tasks</span>
       </div>
 
+      {/* Task input */}
+      <TaskInput bucket={bucket} domains={domains} onCreated={refresh} />
+
       {/* Tasks */}
       <div className="flex-1">
         {pending.length === 0 && completed.length === 0 && (
@@ -100,11 +103,6 @@ export default function BucketPage() {
             ))}
           </div>
         )}
-      </div>
-
-      {/* Task input */}
-      <div className="sticky bottom-0 bg-bg-root pb-2">
-        <TaskInput bucket={bucket} domains={domains} onCreated={refresh} />
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/today/page.tsx
+++ b/frontend/src/app/(app)/today/page.tsx
@@ -117,7 +117,10 @@ export default function TodayPage() {
         </div>
       )}
 
-      {/* Pending tasks */}
+      {/* Task input */}
+      <TaskInput bucket={BUCKET} domains={domains} onCreated={refresh} />
+
+      {/* Task list */}
       <div className="flex-1">
         {pending.length === 0 && completed.length === 0 && (
           <div className="text-center py-12 px-4">
@@ -125,7 +128,7 @@ export default function TodayPage() {
               Nothing on your plate today.
             </p>
             <p className="text-sm text-text-muted mt-1">
-              Add a task below, or check back after morning triage.
+              Add a task above, or check back after morning triage.
             </p>
           </div>
         )}
@@ -144,11 +147,6 @@ export default function TodayPage() {
             ))}
           </div>
         )}
-      </div>
-
-      {/* Task input */}
-      <div className="sticky bottom-0 bg-bg-root pb-2">
-        <TaskInput bucket={BUCKET} domains={domains} onCreated={refresh} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Move task input from sticky bottom (hidden behind nav bar) to above the task list
- Follows the standard task app pattern (Todoist, Things, Apple Reminders): context → input → list
- Applied to both Today page and bucket pages (Soon/Later/Someday)
- Updated empty state copy from "below" to "above"

## Test plan

- [ ] Today page: input appears above tasks, below domain filters
- [ ] Bucket pages: input appears above tasks, below header
- [ ] Input is fully visible (not hidden behind bottom nav)
- [ ] Adding a task still works and refreshes the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)