### PR TITLE
Allow adding unlimited tasks during onboarding

### DIFF
--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -34,6 +34,10 @@ export default function OnboardingPage() {
     { text: "", domainId: undefined as string | undefined },
   ]);
 
+  function addTaskInput() {
+    setTasks((prev) => [...prev, { text: "", domainId: undefined }]);
+  }
+
   // Guard: redirect if already onboarded
   useEffect(() => {
     getMe()
@@ -304,6 +308,14 @@ export default function OnboardingPage() {
               );
             })}
           </div>
+
+          <button
+            type="button"
+            onClick={addTaskInput}
+            className="self-center text-sm text-accent-blue hover:text-accent-blue/80 transition-colors px-3 py-1.5"
+          >
+            + Add another
+          </button>
 
           <div className="flex flex-col items-center gap-3 mt-2">
             {error && (


### PR DESCRIPTION
## Summary
Users can now add unlimited tasks during onboarding instead of being limited to 3. This fixes the friction where users want to add more tasks while excited but hit a wall.

## Changes
- Added `addTaskInput()` function to dynamically append new task inputs
- Added "+ Add another" button below task list (styled as subtle blue link)
- Leverages existing `finishOnboarding()` logic which already filters out empty tasks

## Testing
- [x] Manually tested form state (add 5+ tasks, submit)
- [x] Verified empty tasks are filtered on submit
- [ ] Test on mobile (separate PR #48 for viewport fix)
- [ ] Test with 15+ tasks to verify no scroll/layout breaking

## Refs
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)