### PR TITLE
Improve domain selection discoverability in onboarding

### DIFF
--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -310,7 +310,12 @@ export default function OnboardingPage() {
                     <button
                       type="button"
                       onClick={() => cycleDomain(i)}
-                      className="shrink-0 h-5 w-5 rounded-full border border-border hover:border-text-secondary transition-colors flex items-center justify-center"
+                      className={cn(
+                        "shrink-0 h-5 w-5 rounded-full hover:border-text-secondary transition-colors flex items-center justify-center",
+                        activeDomain
+                          ? "border border-border"
+                          : "border border-dashed border-text-muted"
+                      )}
                       title={activeDomain ? `${activeDomain.name} (click to change)` : "Click to set domain"}
                     >
                       {activeDomain ? (
@@ -334,6 +339,12 @@ export default function OnboardingPage() {
               );
             })}
           </div>
+
+          {domains.length > 0 && (
+            <p className="text-xs text-text-muted text-center">
+              Tip: click the circle next to a task to set its domain
+            </p>
+          )}
 
           <button
             type="button"


### PR DESCRIPTION
## Summary
Users don't realize they can click the colored dot next to each task in onboarding step 3 to assign a domain. This PR makes the interaction more discoverable with visual cues and instructional text.

## Changes
1. **Visual affordance improvement**
   - Unassigned domain button now shows dashed border instead of solid
   - Dashed border signals "actionable placeholder" (common UI pattern)
   - Assigned domains show solid border (current appearance)

2. **Hint text**
   - Added "Tip: click the circle next to a task to set its domain"
   - Shows only when domains exist (domain.length > 0)
   - Positioned below task inputs, before "+ Add another" button
   - Styled as `text-xs text-text-muted text-center` to be subtle but clear

## Before/After
**Before:** Small solid-border circle with tiny "+" text inside — looks decorative
**After:** Dashed-border circle signals interactivity + hint text explains the action

## Testing
- [x] TypeScript compilation passes
- [x] Visual check: dashed border appears on unassigned domains
- [x] Hint text shows only when domains.length > 0
- [ ] Manual test on mobile: verify dashed border visibility
- [ ] Manual test: verify hint text is readable at text-xs size

## Files Changed
- `frontend/src/app/(app)/onboarding/page.tsx`

## Effort
~10 minutes implemented (2 small CSS changes + 3 lines of JSX)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)