### PR TITLE
Fix onboarding completion messaging — set correct expectations

### DIFF
--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -147,19 +147,19 @@ export default function OnboardingPage() {
     return (
       <div className="flex flex-col min-h-screen max-w-lg mx-auto px-4 py-12 gap-8 justify-center items-center text-center">
         <div className="space-y-4">
-          <h1 className="text-3xl font-bold text-text-primary">Almost there</h1>
+          <h1 className="text-3xl font-bold text-text-primary">You&apos;re all set</h1>
           <p className="text-lg text-text-secondary">
-            Next, let's triage. You'll decide which tasks matter today.
+            Your tasks are ready to go. Tomorrow and every morning, you&apos;ll triage them to decide what matters.
           </p>
           <p className="text-sm text-text-muted">
-            This takes about 2 minutes.
+            Head to Today to get started.
           </p>
         </div>
         <button
           onClick={() => router.replace("/today")}
           className="bg-accent-blue text-white rounded-xl px-8 py-3 text-base font-medium hover:bg-accent-blue/90 transition-colors"
         >
-          Go to triage
+          Go to Today
         </button>
       </div>
     );


### PR DESCRIPTION
## Summary
The onboarding completion screen promised \"triage\" but users were sent straight to an empty Today page. This was confusing because tasks created during onboarding are already triaged (stamped with `triaged_at = today`), so they don't reappear in the triage queue.

This PR updates the messaging to set correct expectations and educate users about the daily triage ritual.

## Changes
**Heading:** \"Almost there\" → \"You're all set\"
**Main message:** \"Next, let's triage. You'll decide which tasks matter today.\" → \"Your tasks are ready to go. Tomorrow and every morning, you'll triage them to decide what matters.\"
**Subheading:** \"This takes about 2 minutes.\" → \"Head to Today to get started.\"
**Button:** \"Go to triage\" → \"Go to Today\"

## Why This Fixes It
- Sets correct expectations (no immediate triage)
- Educates about the daily ritual (makes triage feel intentional, not broken)
- Button text matches actual destination
- Acknowledges the user already made choices during onboarding

## Technical Context
Tasks created during onboarding get `triaged_at = date.today()` (backend/app/services/task_service.py:67) to prevent re-triggering the triage gate. The triage queue filters for `triaged_at IS NULL OR triaged_at < today`, so newly created tasks don't match. This is correct behavior — the user just chose these tasks, re-triaging adds no value.

The fix is purely messaging: educate users about the design instead of false promising.

## Testing
- [x] TypeScript compilation passes
- [x] Verify message is clear and educates about daily ritual
- [ ] Manual test: verify copy flows well with the UI

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)