### PR TITLE
Replace domain cycle button with dropdown picker in onboarding

### DIFF
--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { PRESET_COLORS } from "@/lib/constants";
+import { OnboardingDomainPicker } from "@/components/onboarding-domain-picker";
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -95,21 +96,6 @@ export default function OnboardingPage() {
 
   function updateTask(index: number, field: "text" | "domainId", value: string | undefined) {
     setTasks((prev) => prev.map((t, i) => (i === index ? { ...t, [field]: value } : t)));
-  }
-
-  function cycleDomain(index: number) {
-    if (domains.length === 0) return;
-    const current = tasks[index].domainId;
-    if (!current) {
-      updateTask(index, "domainId", domains[0].id);
-    } else {
-      const idx = domains.findIndex((d) => d.id === current);
-      if (idx === domains.length - 1) {
-        updateTask(index, "domainId", undefined);
-      } else {
-        updateTask(index, "domainId", domains[idx + 1].id);
-      }
-    }
   }
 
   async function finishOnboarding(withTasks: boolean) {
@@ -294,57 +280,33 @@ export default function OnboardingPage() {
           <div className="text-center space-y-2">
             <h1 className="text-2xl font-semibold text-text-primary">What&apos;s on your mind?</h1>
             <p className="text-sm text-text-secondary">
-              Add a few things you need to deal with. You can always add more later.
+              Add a few things you need to deal with. Domains help you see where your energy goes &mdash; assign one if you like.
             </p>
           </div>
 
           <div className="space-y-3">
-            {tasks.map((task, i) => {
-              const activeDomain = domains.find((d) => d.id === task.domainId);
-              return (
-                <div
-                  key={i}
-                  className="flex items-center gap-2 rounded-lg bg-bg-card border border-border px-3 py-2.5"
-                >
-                  {domains.length > 0 && (
-                    <button
-                      type="button"
-                      onClick={() => cycleDomain(i)}
-                      className={cn(
-                        "shrink-0 h-5 w-5 rounded-full hover:border-text-secondary transition-colors flex items-center justify-center",
-                        activeDomain
-                          ? "border border-border"
-                          : "border border-dashed border-text-muted"
-                      )}
-                      title={activeDomain ? `${activeDomain.name} (click to change)` : "Click to set domain"}
-                    >
-                      {activeDomain ? (
-                        <span
-                          className="h-2.5 w-2.5 rounded-full"
-                          style={{ backgroundColor: activeDomain.color }}
-                        />
-                      ) : (
-                        <span className="text-text-muted text-[10px]">+</span>
-                      )}
-                    </button>
-                  )}
-                  <input
-                    value={task.text}
-                    onChange={(e) => updateTask(i, "text", e.target.value)}
-                    placeholder={["e.g. Review quarterly goals", "e.g. Schedule dentist", "e.g. Read that article"][i]}
-                    maxLength={500}
-                    className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none"
+            {tasks.map((task, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-2 rounded-lg bg-bg-card border border-border px-3 py-2.5"
+              >
+                {domains.length > 0 && (
+                  <OnboardingDomainPicker
+                    currentDomainId={task.domainId}
+                    domains={domains}
+                    onChange={(domainId) => updateTask(i, "domainId", domainId)}
                   />
-                </div>
-              );
-            })}
+                )}
+                <input
+                  value={task.text}
+                  onChange={(e) => updateTask(i, "text", e.target.value)}
+                  placeholder={["e.g. Review quarterly goals", "e.g. Schedule dentist", "e.g. Read that article"][i]}
+                  maxLength={500}
+                  className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none"
+                />
+              </div>
+            ))}
           </div>
-
-          {domains.length > 0 && (
-            <p className="text-xs text-text-muted text-center">
-              Tip: click the circle next to a task to set its domain
-            </p>
-          )}
 
           <button
             type="button"

--- a/frontend/src/components/onboarding-domain-picker.tsx
+++ b/frontend/src/components/onboarding-domain-picker.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import type { Domain } from "@/lib/api-types";
+import { cn } from "@/lib/utils";
+
+interface OnboardingDomainPickerProps {
+  currentDomainId: string | undefined;
+  domains: Domain[];
+  onChange: (domainId: string | undefined) => void;
+}
+
+/**
+ * Local-state domain picker for onboarding. Same visual design as
+ * DomainPicker but operates on local state via onChange callback
+ * instead of calling the tasks API.
+ */
+export function OnboardingDomainPicker({
+  currentDomainId,
+  domains,
+  onChange,
+}: OnboardingDomainPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const currentDomain = domains.find((d) => d.id === currentDomainId);
+
+  // Click-outside and Escape handlers
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      const target = e.target;
+      if (target instanceof Node && ref.current && !ref.current.contains(target)) {
+        setIsOpen(false);
+      }
+    }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen]);
+
+  function selectDomain(domainId: string | undefined) {
+    if (domainId === currentDomainId) {
+      setIsOpen(false);
+      return;
+    }
+    onChange(domainId);
+    setIsOpen(false);
+  }
+
+  return (
+    <div className="relative shrink-0" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          "h-5 w-5 rounded-full border flex items-center justify-center transition-colors",
+          currentDomain
+            ? "border-border hover:border-text-secondary"
+            : "border-dashed border-text-muted hover:border-text-secondary",
+        )}
+        aria-label={currentDomain ? `Domain: ${currentDomain.name}. Click to change` : "Set domain"}
+        aria-expanded={isOpen}
+        title={currentDomain ? `${currentDomain.name} (click to change)` : "Set domain"}
+      >
+        {currentDomain ? (
+          <span
+            className="h-2.5 w-2.5 rounded-full"
+            style={{ backgroundColor: currentDomain.color }}
+          />
+        ) : (
+          <span className="text-text-muted text-[10px]">+</span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 z-10 flex items-center gap-1 bg-bg-card border border-border rounded-lg px-1.5 py-1.5 shadow-lg">
+          {domains.map((d) => (
+            <button
+              key={d.id}
+              type="button"
+              onClick={() => selectDomain(d.id)}
+              className={cn(
+                "flex items-center gap-1 px-1.5 py-1 rounded-md transition-colors",
+                currentDomainId === d.id
+                  ? "bg-bg-hover"
+                  : "hover:bg-bg-hover",
+              )}
+              aria-label={`Set domain to ${d.name}`}
+              title={d.name}
+            >
+              <span
+                className="h-2.5 w-2.5 rounded-full shrink-0"
+                style={{ backgroundColor: d.color }}
+              />
+              <span className="text-[10px] text-text-secondary whitespace-nowrap">{d.name}</span>
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => selectDomain(undefined)}
+            className={cn(
+              "flex items-center gap-1 px-1.5 py-1 rounded-md transition-colors",
+              !currentDomainId
+                ? "bg-bg-hover"
+                : "hover:bg-bg-hover",
+            )}
+            aria-label="Clear domain"
+            title="None"
+          >
+            <span className="h-2.5 w-2.5 rounded-full border border-text-muted shrink-0" />
+            <span className="text-[10px] text-text-muted whitespace-nowrap">None</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Replace confusing cycle-on-click domain button with the same dropdown picker pattern used in the main app
- Create `OnboardingDomainPicker` component — local-state variant of `DomainPicker` (no API calls, uses `onChange` callback)
- Update Step 3 copy to explain why domains matter: "Domains help you see where your energy goes — assign one if you like"
- Remove "Tip: click the circle..." hint text (dropdown is self-evident)
- Remove unused `cycleDomain()` function

## Test plan

- [ ] Step through onboarding to Step 3
- [ ] Click domain circle — should show dropdown with all domains + "None"
- [ ] Select a domain — circle fills with domain color
- [ ] Select "None" — circle returns to dashed placeholder
- [ ] Click outside dropdown — should close
- [ ] Press Escape — should close
- [ ] Verify domain persists through "Done" (task created with correct domain_id)
- [ ] Verify flow works with 0 domains (picker hidden, tasks created without domain)

Refs #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)