### PR TITLE
Add guided first-time triage after onboarding

### DIFF
--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -70,6 +70,15 @@ def create_task(
     db: Session = Depends(get_db),
     user_id: uuid.UUID = Depends(get_current_user_id),
 ):
+    # Only honor skip_triage_stamp during onboarding (prevents abuse after onboarding)
+    skip_stamp = False
+    if body.skip_triage_stamp:
+        from app.models.user import User
+
+        user = db.get(User, user_id)
+        if user and not user.has_completed_onboarding:
+            skip_stamp = True
+
     task = task_service.create_task(
         db,
         user_id,
@@ -77,6 +86,7 @@ def create_task(
         bucket=body.bucket,
         domain_id=body.domain_id,
         parent_id=body.parent_id,
+        skip_triage_stamp=skip_stamp,
     )
     # Reload with relationships for response
     task = task_service.get_task(db, user_id, task.id)

--- a/backend/app/schemas/task_schemas.py
+++ b/backend/app/schemas/task_schemas.py
@@ -11,6 +11,7 @@ class TaskCreate(BaseModel):
     bucket: BucketType = BucketType.today
     domain_id: uuid.UUID | None = None
     parent_id: uuid.UUID | None = None
+    skip_triage_stamp: bool = False
 
 
 class TaskUpdate(BaseModel):

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -28,6 +28,7 @@ def create_task(
     bucket: BucketType = BucketType.today,
     domain_id: uuid.UUID | None = None,
     parent_id: uuid.UUID | None = None,
+    skip_triage_stamp: bool = False,
 ) -> Task:
     if len(text) > 500:
         raise AppError(
@@ -64,7 +65,7 @@ def create_task(
         status=TaskStatus.pending,
         domain_id=domain_id,
         parent_id=parent_id,
-        triaged_at=date.today(),  # prevent re-triggering triage gate
+        triaged_at=None if skip_triage_stamp else date.today(),
     )
     db.add(task)
     db.flush()

--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -106,7 +106,7 @@ export default function OnboardingPage() {
       if (withTasks) {
         const toCreate = tasks.filter((t) => t.text.trim());
         await Promise.all(
-          toCreate.map((t) => createTask({ text: t.text.trim(), bucket: "today", domain_id: t.domainId })),
+          toCreate.map((t) => createTask({ text: t.text.trim(), bucket: "today", domain_id: t.domainId, skip_triage_stamp: true })),
         );
       }
       await updateMe({ has_completed_onboarding: true });
@@ -128,24 +128,21 @@ export default function OnboardingPage() {
     );
   }
 
-  // "Ready to triage?" screen after onboarding completes
+  // Post-onboarding: prompt first triage
   if (showTriageReady) {
     return (
       <div className="flex flex-col min-h-screen max-w-lg mx-auto px-4 py-12 gap-8 justify-center items-center text-center">
         <div className="space-y-4">
-          <h1 className="text-3xl font-bold text-text-primary">You&apos;re all set</h1>
+          <h1 className="text-3xl font-bold text-text-primary">Let&apos;s do your first triage</h1>
           <p className="text-lg text-text-secondary">
-            Your tasks are ready to go. Tomorrow and every morning, you&apos;ll triage them to decide what matters.
-          </p>
-          <p className="text-sm text-text-muted">
-            Head to Today to get started.
+            Each morning, you&apos;ll review your tasks and decide what matters today. It takes about 30 seconds.
           </p>
         </div>
         <button
           onClick={() => router.replace("/today")}
           className="bg-accent-blue text-white rounded-xl px-8 py-3 text-base font-medium hover:bg-accent-blue/90 transition-colors"
         >
-          Go to Today
+          Start Triage
         </button>
       </div>
     );

--- a/frontend/src/components/triage-modal.tsx
+++ b/frontend/src/components/triage-modal.tsx
@@ -17,6 +17,8 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
   const [loading, setLoading] = useState(!initialQueue);
   const [showHints, setShowHints] = useState(false);
   const [showExplainer, setShowExplainer] = useState(false);
+  const [isFirstTriage, setIsFirstTriage] = useState(false);
+  const [showFirstComplete, setShowFirstComplete] = useState(false);
 
   useEffect(() => {
     const queuePromise = initialQueue
@@ -32,6 +34,7 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
         setQueue(q);
         setShowHints(!user.has_triaged_before);
         setShowExplainer(!user.has_triaged_before);
+        setIsFirstTriage(!user.has_triaged_before);
         setLoading(false);
       })
       .catch(() => {
@@ -41,7 +44,11 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
 
   function handleAction(result: { triage_complete: boolean; remaining: number }) {
     if (result.triage_complete || result.remaining === 0 || !queue || currentIndex >= queue.tasks.length - 1) {
-      onComplete();
+      if (isFirstTriage) {
+        setShowFirstComplete(true);
+      } else {
+        onComplete();
+      }
       return;
     }
     setCurrentIndex((i) => i + 1);
@@ -71,7 +78,22 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
 
   return (
     <RitualOverlay>
-      {showExplainer ? (
+      {showFirstComplete ? (
+        <div className="flex flex-col items-center gap-6 px-4 w-full max-w-lg mx-auto">
+          <div className="w-full rounded-2xl bg-bg-card border border-border p-6 space-y-4 text-center">
+            <h2 className="text-xl font-semibold text-text-primary">That&apos;s your morning triage</h2>
+            <p className="text-sm text-text-secondary leading-relaxed">
+              Tomorrow and every morning, you&apos;ll do this again. It keeps your Today list intentional.
+            </p>
+          </div>
+          <button
+            onClick={() => onComplete()}
+            className="bg-accent-blue text-white rounded-xl px-8 py-3 text-base font-medium hover:bg-accent-blue/90 transition-colors"
+          >
+            Go to Today
+          </button>
+        </div>
+      ) : showExplainer ? (
         <div className="flex flex-col items-center gap-6 px-4 w-full max-w-lg mx-auto">
           <div className="w-full rounded-2xl bg-bg-card border border-border p-6 space-y-4 text-center">
             <h2 className="text-xl font-semibold text-text-primary">Morning Triage</h2>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -60,6 +60,7 @@ export async function createTask(body: {
   bucket?: BucketType;
   domain_id?: string;
   parent_id?: string;
+  skip_triage_stamp?: boolean;
 }): Promise<Task> {
   return request<Task>("tasks", { method: "POST", body: JSON.stringify(body) });
 }


### PR DESCRIPTION
## Summary

- After onboarding, users now experience triage with their initial tasks instead of landing on a static Today list
- Backend: `skip_triage_stamp` parameter lets onboarding tasks enter triage queue (only honored during onboarding to prevent abuse)
- Frontend: Completion screen says "Let's do your first triage" → triage gate fires → existing first-time explainer + hints provide coaching
- New first-triage completion message: "That's your morning triage. Tomorrow and every morning, you'll do this again."

## Test plan

- [ ] Create new account, go through onboarding, add tasks in Step 3
- [ ] After "Done", see "Let's do your first triage" screen
- [ ] Click "Start Triage" → triage modal opens with "Morning Triage" explainer
- [ ] Triage all tasks (confirm/defer/kill) — hints visible on action buttons
- [ ] After last task: see "That's your morning triage" completion message
- [ ] Click "Go to Today" → land on Today with confirmed tasks
- [ ] Next day: triage fires normally (no coaching overlay, no completion message)
- [ ] Verify `skip_triage_stamp` is ignored after onboarding (POST /tasks with flag after onboarding should still stamp triaged_at)
- [ ] Run backend tests: all 75 pass

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)