### PR TITLE
Add persistent upgrade CTA, pro perks, and ProBadge (#75)

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import type { TriageQueue } from "@/lib/api-types";
-import { getTriageQueue, getMe } from "@/lib/api";
+import type { TriageQueue, User } from "@/lib/api-types";
+import { getTriageQueue, getMe, createCheckout } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/components/theme-provider";
 import { TriageModal } from "@/components/triage-modal";
@@ -48,6 +48,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const [showTriageModal, setShowTriageModal] = useState(false);
   const [showWinddownModal, setShowWinddownModal] = useState(false);
   const [triageQueue, setTriageQueue] = useState<TriageQueue | undefined>(undefined);
+  const [user, setUser] = useState<User | null>(null);
+  const [upgradeLoading, setUpgradeLoading] = useState(false);
   const onboardingVerified = useRef(false);
 
   const { theme, toggle: toggleTheme } = useTheme();
@@ -70,9 +72,10 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     }
     let cancelled = false;
     getMe()
-      .then((user) => {
+      .then((u) => {
         if (cancelled) return;
-        if (!user.has_completed_onboarding) {
+        setUser(u);
+        if (!u.has_completed_onboarding) {
           router.replace("/onboarding");
         } else {
           onboardingVerified.current = true;
@@ -162,8 +165,28 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             </button>
           </div>
 
-          {/* Bottom section — theme toggle + settings */}
+          {/* Bottom section — upgrade CTA + theme toggle + settings */}
           <div className="mt-auto mx-3 pt-3 pb-4 border-t border-border/50 flex flex-col gap-0.5">
+            {user && !user.is_pro && (
+              <button
+                onClick={async () => {
+                  if (upgradeLoading) return;
+                  setUpgradeLoading(true);
+                  try {
+                    const { checkout_url } = await createCheckout();
+                    window.location.href = checkout_url;
+                  } catch (err) {
+                    console.error("Failed to create checkout:", err);
+                    setUpgradeLoading(false);
+                  }
+                }}
+                disabled={upgradeLoading}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] transition-colors duration-150 w-full text-amber-500/70 hover:text-amber-500 hover:bg-amber-500/5 disabled:opacity-50"
+              >
+                <span className="text-[15px]" aria-hidden>✦</span>
+                <span>{upgradeLoading ? "Loading..." : "Upgrade to Pro"}</span>
+              </button>
+            )}
             <button
               onClick={toggleTheme}
               className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] transition-colors duration-150 w-full text-text-muted hover:text-text-secondary hover:bg-bg-hover/50"

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -263,33 +263,52 @@ function SettingsContent() {
             </div>
           )}
 
-          <div className="flex items-center gap-3 rounded-lg bg-bg-card border border-border px-4 py-3">
-            <div className="flex-1">
-              <p className="text-sm font-medium text-text-primary">
-                {user.is_pro ? "Pro" : "Free"}
-              </p>
-              <p className="text-xs text-text-muted">
-                {user.is_pro
-                  ? "You have access to all features."
-                  : "Upgrade for premium features."}
-              </p>
+          <div className="rounded-lg bg-bg-card border border-border px-4 py-3 space-y-3">
+            <div className="flex items-center gap-3">
+              <div className="flex-1">
+                <p className="text-sm font-medium text-text-primary">
+                  {user.is_pro ? "Pro" : "Free"}
+                </p>
+                <p className="text-xs text-text-muted">
+                  {user.is_pro
+                    ? "You have access to all Pro features."
+                    : "Upgrade to unlock more from Tend."}
+                </p>
+              </div>
+              {user.is_pro ? (
+                <button
+                  onClick={handleManageBilling}
+                  disabled={billingLoading}
+                  className="text-sm text-text-secondary border border-border rounded-lg px-4 py-2 hover:bg-bg-hover transition-colors disabled:opacity-50"
+                >
+                  {billingLoading ? "Loading..." : "Manage billing"}
+                </button>
+              ) : (
+                <button
+                  onClick={handleUpgrade}
+                  disabled={billingLoading}
+                  className="text-sm text-white bg-accent-blue rounded-lg px-4 py-2 hover:bg-accent-blue/90 transition-colors disabled:opacity-50"
+                >
+                  {billingLoading ? "Loading..." : "Upgrade to Pro"}
+                </button>
+              )}
             </div>
-            {user.is_pro ? (
-              <button
-                onClick={handleManageBilling}
-                disabled={billingLoading}
-                className="text-sm text-text-secondary border border-border rounded-lg px-4 py-2 hover:bg-bg-hover transition-colors disabled:opacity-50"
-              >
-                {billingLoading ? "Loading..." : "Manage billing"}
-              </button>
-            ) : (
-              <button
-                onClick={handleUpgrade}
-                disabled={billingLoading}
-                className="text-sm text-white bg-accent-blue rounded-lg px-4 py-2 hover:bg-accent-blue/90 transition-colors disabled:opacity-50"
-              >
-                {billingLoading ? "Loading..." : "Upgrade to Pro"}
-              </button>
+
+            {!user.is_pro && (
+              <ul className="text-xs text-text-muted space-y-1.5 pt-1 border-t border-border/50">
+                <li className="flex items-start gap-2">
+                  <span className="text-amber-500/70 mt-px">✦</span>
+                  <span>Up to 10 life domains (free: 5)</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="text-amber-500/70 mt-px">✦</span>
+                  <span>Priority support and early access to new features</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="text-amber-500/70 mt-px">✦</span>
+                  <span>Support Tend&apos;s continued development</span>
+                </li>
+              </ul>
             )}
           </div>
         </section>

--- a/frontend/src/components/pro-badge.tsx
+++ b/frontend/src/components/pro-badge.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+interface ProBadgeProps {
+  className?: string;
+  tooltip?: string;
+}
+
+export function ProBadge({ className, tooltip = "Available with Pro" }: ProBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[10px] font-medium tracking-wide uppercase text-amber-500/80 bg-amber-500/10 rounded px-1.5 py-0.5 ${className ?? ""}`}
+      title={tooltip}
+    >
+      <span aria-hidden>✦</span>
+      Pro
+    </span>
+  );
+}


### PR DESCRIPTION
Closes #75

## Summary
- **Nav CTA**: Subtle "✦ Upgrade to Pro" link in sidebar bottom section for free users. Triggers Stripe checkout. Hidden entirely for pro users.
- **Settings perks**: Subscription section now shows specific pro benefits (10 domains, priority support, support development) instead of vague "premium features".
- **ProBadge component**: Reusable `<ProBadge />` with amber ✦ styling and tooltip, ready for future feature gating.

## Design
- Amber/gold color palette (`text-amber-500/70`) for pro elements — distinct from the app's blue accent
- CTA positioned below wind-down, above theme toggle — visible but not pushy
- Perks list uses `✦` bullets matching the CTA for visual consistency

## Test plan
- [ ] Log in as free user → see "✦ Upgrade to Pro" in sidebar
- [ ] Click upgrade → redirects to Stripe checkout
- [ ] Log in as pro user → no upgrade link visible anywhere
- [ ] Settings page: free user sees perks list under subscription
- [ ] Settings page: pro user sees "Manage billing" with no perks list
- [ ] Build passes (`next build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)