### PR TITLE
feat: add domain picker hint on onboarding step 3

### DIFF
--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -255,6 +255,9 @@ export default function OnboardingPage() {
             <p className="text-sm text-text-secondary">
               Add a few things you need to deal with. Think small &mdash; what could you actually finish today?
             </p>
+            {selectedDomains.length > 0 && (
+              <p className="text-xs text-text-muted">Tap ⊕ to assign a life area</p>
+            )}
           </div>
 
           <div className="space-y-3">


### PR DESCRIPTION
## Summary
- Adds inline hint text "Tap ⊕ to assign a life area" on onboarding step 3, shown only when the user has selected domains
- Closes #72

## Test plan
- [ ] Complete onboarding steps 1-2 with at least one domain selected → step 3 shows the hint
- [ ] Complete onboarding steps 1-2 with zero domains → step 3 does not show the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)