### PR TITLE
Add GET /triage/briefing endpoint with Pro gate (#85)

### DIFF
--- a/backend/app/api/triage.py
+++ b/backend/app/api/triage.py
@@ -6,10 +6,22 @@ from sqlmodel import Session
 
 from app.api.tasks import _to_response
 from app.core.deps import get_db
+from app.core.errors import AppError
 from app.core.security import get_current_user_id
+from app.models.user import User
 from app.schemas.task_schemas import TaskResponse
-from app.schemas.triage_schemas import TriageQueueResponse, TriageRequest, TriageResultResponse
-from app.services import composter_service, triage_service
+from app.schemas.triage_schemas import (
+    BriefingResponse,
+    TriageQueueResponse,
+    TriageRequest,
+    TriageResultResponse,
+)
+from app.services import (
+    briefing_service,
+    composter_service,
+    stats_service,
+    triage_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +50,29 @@ def get_triage_queue(
         total_count=result["total_count"],
         completion_average=result["completion_average"],
         triage_complete=result["triage_complete"],
+    )
+
+
+@router.get("/briefing", response_model=BriefingResponse)
+def get_briefing(
+    db: Session = Depends(get_db),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+):
+    user = db.get(User, user_id)
+    is_pro = user.subscription_status in ("active", "past_due")
+    if not is_pro:
+        raise AppError(
+            code="pro_required",
+            message="AI briefing requires a Pro subscription",
+            status_code=403,
+        )
+
+    result = triage_service.get_triage_tasks(db, user_id)
+    nudge = stats_service.get_nudge(db, user_id)
+
+    return briefing_service.generate_briefing(
+        tasks=result["tasks"],
+        nudge_stats=nudge,
     )
 
 

--- a/backend/tests/test_triage.py
+++ b/backend/tests/test_triage.py
@@ -1,7 +1,9 @@
 from datetime import date
+from unittest.mock import patch
 
 from app.models.enums import BucketType, TaskStatus
 from app.models.task import Task
+from app.schemas.triage_schemas import BriefingResponse
 
 
 class TestTriageFlow:
@@ -116,3 +118,46 @@ class TestTriageFlow:
         r = client.get("/triage/winddown")
         assert r.status_code == 200
         assert len(r.json()) == 5  # All 5 tasks are today+pending
+
+
+class TestBriefingEndpoint:
+    @patch("app.api.triage.briefing_service.generate_briefing")
+    def test_pro_user_gets_briefing(
+        self, mock_gen, client, test_user, test_tasks, db
+    ):
+        test_user.subscription_status = "active"
+        db.flush()
+
+        mock_gen.return_value = BriefingResponse(
+            summary="5 tasks",
+            domain_balance="Heavy on Work",
+            calibration="You average 4",
+        )
+
+        r = client.get("/triage/briefing")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["summary"] == "5 tasks"
+        assert data["domain_balance"] == "Heavy on Work"
+        assert data["calibration"] == "You average 4"
+        mock_gen.assert_called_once()
+
+    def test_free_user_gets_403(self, client, test_user):
+        r = client.get("/triage/briefing")
+        assert r.status_code == 403
+        assert r.json()["code"] == "pro_required"
+
+    @patch("app.api.triage.briefing_service.generate_briefing")
+    def test_empty_briefing_returns_200(
+        self, mock_gen, client, test_user, db
+    ):
+        test_user.subscription_status = "active"
+        db.flush()
+
+        mock_gen.return_value = BriefingResponse()
+
+        r = client.get("/triage/briefing")
+        assert r.status_code == 200
+        assert r.json()["summary"] == ""
+        assert r.json()["domain_balance"] == ""
+        assert r.json()["calibration"] == ""


### PR DESCRIPTION
Closes #85

## Summary
- `GET /triage/briefing` returns AI-generated `BriefingResponse` for Pro users
- Returns 403 with `pro_required` code for free users
- Fetches untriaged tasks + nudge stats, delegates to `briefing_service`
- Empty/fallback briefing returns 200 with empty fields
- 3 new tests, 119 total passing

## Test plan
- [x] Pro user gets briefing with mocked service
- [x] Free user gets 403 with correct error code
- [x] Empty briefing from service returns 200
- [x] Full suite passes (119 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)