### PR TITLE
Add briefing card UI to triage modal (#86)

### DIFF
--- a/frontend/src/components/triage-modal.tsx
+++ b/frontend/src/components/triage-modal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { TriageQueue } from "@/lib/api-types";
-import { getTriageQueue, getMe } from "@/lib/api";
+import type { BriefingResponse, TriageQueue } from "@/lib/api-types";
+import { getTriageQueue, getMe, getTriageBriefing, createCheckout } from "@/lib/api";
 import { TriageCard } from "@/components/triage-card";
 import { RitualOverlay } from "@/components/ritual-overlay";
+import { ProBadge } from "@/components/pro-badge";
 
 interface TriageModalProps {
   onComplete: () => void;
@@ -19,6 +20,11 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
   const [showExplainer, setShowExplainer] = useState(false);
   const [isFirstTriage, setIsFirstTriage] = useState(false);
   const [showFirstComplete, setShowFirstComplete] = useState(false);
+  const [showBriefing, setShowBriefing] = useState(false);
+  const [briefing, setBriefing] = useState<BriefingResponse | null>(null);
+  const [briefingLoading, setBriefingLoading] = useState(false);
+  const [showFreeTeaser, setShowFreeTeaser] = useState(false);
+  const [upgradeLoading, setUpgradeLoading] = useState(false);
 
   useEffect(() => {
     const queuePromise = initialQueue
@@ -33,9 +39,36 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
         }
         setQueue(q);
         setShowHints(!user.has_triaged_before);
-        setShowExplainer(!user.has_triaged_before);
         setIsFirstTriage(!user.has_triaged_before);
-        setLoading(false);
+
+        if (!user.has_triaged_before) {
+          // First-time users see the explainer, not briefing
+          setShowExplainer(true);
+          setLoading(false);
+        } else if (user.is_pro) {
+          // Pro returning users get AI briefing
+          setBriefingLoading(true);
+          setShowBriefing(true);
+          setLoading(false);
+          getTriageBriefing()
+            .then((b) => {
+              if (b.summary || b.domain_balance || b.calibration) {
+                setBriefing(b);
+              } else {
+                // Empty briefing — skip to cards
+                setShowBriefing(false);
+              }
+            })
+            .catch(() => {
+              // API failure — skip briefing silently
+              setShowBriefing(false);
+            })
+            .finally(() => setBriefingLoading(false));
+        } else {
+          // Free returning users see teaser
+          setShowFreeTeaser(true);
+          setLoading(false);
+        }
       })
       .catch((err) => {
         console.error("Failed to load triage queue:", err);
@@ -53,6 +86,16 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
       return;
     }
     setCurrentIndex((i) => i + 1);
+  }
+
+  async function handleUpgrade() {
+    setUpgradeLoading(true);
+    try {
+      const { checkout_url } = await createCheckout();
+      window.location.href = checkout_url;
+    } catch {
+      setUpgradeLoading(false);
+    }
   }
 
   if (loading) {
@@ -92,6 +135,74 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
             className="bg-accent-blue text-white rounded-xl px-8 py-3 text-base font-medium hover:bg-accent-blue/90 transition-colors"
           >
             Go to Today
+          </button>
+        </div>
+      ) : showBriefing ? (
+        <div className="flex flex-col items-center gap-6 px-4 w-full max-w-lg mx-auto">
+          <div className="w-full rounded-2xl bg-bg-card border border-border p-6 space-y-4">
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold text-text-primary">Morning Briefing</h2>
+              <ProBadge />
+            </div>
+
+            {briefingLoading ? (
+              <div className="space-y-3 animate-pulse">
+                <div className="h-4 bg-bg-hover rounded w-3/4" />
+                <div className="h-4 bg-bg-hover rounded w-full" />
+                <div className="h-4 bg-bg-hover rounded w-2/3" />
+              </div>
+            ) : briefing ? (
+              <div className="space-y-3">
+                {briefing.summary && (
+                  <p className="text-sm text-text-secondary leading-relaxed">
+                    {briefing.summary}
+                  </p>
+                )}
+                {briefing.domain_balance && (
+                  <p className="text-sm text-text-secondary leading-relaxed">
+                    {briefing.domain_balance}
+                  </p>
+                )}
+                {briefing.calibration && (
+                  <p className="text-sm text-amber-500/80 leading-relaxed">
+                    {briefing.calibration}
+                  </p>
+                )}
+              </div>
+            ) : null}
+          </div>
+          <button
+            onClick={() => setShowBriefing(false)}
+            disabled={briefingLoading}
+            className="bg-accent-blue text-white rounded-xl px-8 py-3 text-base font-medium hover:bg-accent-blue/90 transition-colors disabled:opacity-50"
+          >
+            Start triaging
+          </button>
+        </div>
+      ) : showFreeTeaser ? (
+        <div className="flex flex-col items-center gap-6 px-4 w-full max-w-lg mx-auto">
+          <div className="w-full rounded-2xl bg-bg-card border border-border p-6 space-y-4">
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold text-text-primary">Morning Briefing</h2>
+              <ProBadge />
+            </div>
+            <p className="text-sm text-text-secondary leading-relaxed">
+              Pro members get an AI-generated briefing before triage — a quick
+              summary of your queue, domain balance, and capacity check.
+            </p>
+            <button
+              onClick={handleUpgrade}
+              disabled={upgradeLoading}
+              className="w-full text-sm text-amber-500 border border-amber-500/30 rounded-lg px-4 py-2 hover:bg-amber-500/10 transition-colors disabled:opacity-50"
+            >
+              {upgradeLoading ? "Loading..." : "Upgrade to Pro"}
+            </button>
+          </div>
+          <button
+            onClick={() => setShowFreeTeaser(false)}
+            className="bg-accent-blue text-white rounded-xl px-8 py-3 text-base font-medium hover:bg-accent-blue/90 transition-colors"
+          >
+            Start triaging
           </button>
         </div>
       ) : showExplainer ? (

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -59,6 +59,13 @@ export interface TriageResult {
   remaining: number;
 }
 
+// Briefing
+export interface BriefingResponse {
+  summary: string;
+  domain_balance: string;
+  calibration: string;
+}
+
 // Stats
 export interface NudgeStats {
   today_count: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   BillingStatus,
+  BriefingResponse,
   BucketType,
   CheckoutResponse,
   Domain,
@@ -96,6 +97,10 @@ export async function submitTriage(
     method: "POST",
     body: JSON.stringify(body),
   });
+}
+
+export async function getTriageBriefing(): Promise<BriefingResponse> {
+  return request<BriefingResponse>("triage/briefing");
 }
 
 export async function getWinddown(): Promise<Task[]> {


### PR DESCRIPTION
Closes #86

## Summary
- `BriefingResponse` type in `api-types.ts` + `getTriageBriefing()` in `api.ts`
- Pro users see AI briefing card (summary, domain balance, calibration) before triage cards
- Loading skeleton while AI responds
- Free users see teaser card with ProBadge + upgrade CTA (links to Stripe checkout)
- First-time users still see the onboarding explainer (briefing skipped)
- API failure skips briefing silently — triage flow unaffected
- "Start triaging" button dismisses briefing/teaser and enters card flow

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Backend tests still pass (119/119)
- [ ] Manual: Pro user sees briefing card with AI content
- [ ] Manual: Free user sees teaser with upgrade button
- [ ] Manual: First-time user sees explainer (no briefing)
- [ ] Manual: If backend has no ANTHROPIC_API_KEY, briefing skips silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)