### PR TITLE
Redirect logged-in users to /today and extend session to 90 days

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -51,7 +51,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       },
     }),
   ],
-  session: { strategy: "jwt" },
+  session: { strategy: "jwt", maxAge: 90 * 24 * 60 * 60 },
   pages: {
     signIn: "/login",
   },

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -13,8 +13,8 @@ export default auth((req) => {
     pathname === "/reset-password" ||
     pathname.startsWith("/api/auth");
 
-  // Redirect authenticated users away from auth pages
-  if (isLoggedIn && (pathname === "/login" || pathname === "/signup")) {
+  // Redirect authenticated users away from auth/marketing pages into the app
+  if (isLoggedIn && (pathname === "/" || pathname === "/login" || pathname === "/signup")) {
     return Response.redirect(new URL("/today", req.nextUrl.origin));
   }
 


### PR DESCRIPTION
## Summary
- Authenticated users visiting `/` now redirect to `/today` instead of seeing the marketing landing page
- Session maxAge extended from 30 days (default) to 90 days so users stay logged in longer

## Test plan
- [ ] Visit tendyourgarden.app while logged in → should redirect to `/today`
- [ ] Visit tendyourgarden.app while logged out → should show marketing page
- [ ] Check session cookie expiry in browser dev tools → should be ~90 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)