### PR TITLE
enhancement: stabilize task input layout to prevent reflow (#100)

### DIFF
--- a/frontend/src/app/(app)/bucket/[b]/page.tsx
+++ b/frontend/src/app/(app)/bucket/[b]/page.tsx
@@ -144,9 +144,9 @@ export default function BucketPage() {
       <TaskInput bucket={bucket} domains={domains} onCreated={refresh} />
 
       {/* Tasks */}
-      <div className="flex-1">
+      <div className="flex-1 min-h-[120px]">
         {pending.length === 0 && completed.length === 0 && (
-          <div className="text-center py-12 px-4">
+          <div className="text-center py-8 px-4">
             <p className="text-base text-text-secondary">
               {EMPTY_MESSAGES[bucket] ?? "No tasks here yet."}
             </p>

--- a/frontend/src/app/(app)/today/page.tsx
+++ b/frontend/src/app/(app)/today/page.tsx
@@ -121,9 +121,9 @@ export default function TodayPage() {
       <TaskInput bucket={BUCKET} domains={domains} onCreated={refresh} />
 
       {/* Task list */}
-      <div className="flex-1">
+      <div className="flex-1 min-h-[120px]">
         {pending.length === 0 && completed.length === 0 && (
-          <div className="text-center py-12 px-4">
+          <div className="text-center py-8 px-4">
             <p className="text-base text-text-secondary">
               Nothing on your plate today.
             </p>


### PR DESCRIPTION
Closes #100

## Summary
- Add `min-h-[120px]` to task list containers on Today and Bucket pages to reserve stable vertical space
- Reduce empty state padding from `py-12` to `py-8` so the message fits within the reserved height
- When first task is created, the container is already sized — no layout shift

## Changes
- `frontend/src/app/(app)/today/page.tsx` — min-height + reduced padding
- `frontend/src/app/(app)/bucket/[b]/page.tsx` — same treatment

## Test plan
- [ ] Open Today page with no tasks — empty state message visible, input above it
- [ ] Create a task — no visible layout jump
- [ ] Same test on Soon, Later, Someday pages
- [ ] Verify task creation still works (text + domain cycling + character counter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)