### PR TITLE
feat: two-phase task creation with domain chip selector (#101)

### DIFF
--- a/frontend/src/components/task-input.tsx
+++ b/frontend/src/components/task-input.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import type { BucketType, Domain } from "@/lib/api-types";
 import { createTask } from "@/lib/api";
+
+type Phase = "typing" | "selecting" | "submitting";
 
 interface TaskInputProps {
   bucket: BucketType;
@@ -12,79 +14,177 @@ interface TaskInputProps {
 
 export function TaskInput({ bucket, domains, onCreated }: TaskInputProps) {
   const [text, setText] = useState("");
-  const [domainId, setDomainId] = useState<string | undefined>();
-  const [loading, setLoading] = useState(false);
+  const [phase, setPhase] = useState<Phase>("typing");
+  // Index into [undefined, ...domains] where undefined = "None"
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const chipContainerRef = useRef<HTMLDivElement>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
+  const hasDomains = domains.length > 0;
+  // Options: [undefined (None), domain0, domain1, ...]
+  const optionCount = domains.length + 1;
+
+  const resetToTyping = useCallback(() => {
+    setText("");
+    setSelectedIndex(0);
+    setPhase("typing");
+    // Focus input on next tick after state update
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, []);
+
+  const submitTask = useCallback(async (taskText: string, domainIndex: number) => {
+    setPhase("submitting");
+    const domainId = domainIndex > 0 ? domains[domainIndex - 1]?.id : undefined;
+    try {
+      await createTask({ text: taskText, bucket, domain_id: domainId });
+      onCreated();
+    } catch (err) {
+      console.error("Failed to create task:", err);
+    }
+    resetToTyping();
+  }, [bucket, domains, onCreated, resetToTyping]);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key !== "Enter") return;
     e.preventDefault();
     const trimmed = text.trim();
-    if (!trimmed || loading) return;
-    setLoading(true);
-    await createTask({ text: trimmed, bucket, domain_id: domainId });
-    setText("");
-    setLoading(false);
-    onCreated();
+    if (!trimmed || phase !== "typing") return;
+
+    if (!hasDomains) {
+      // No domains — skip Phase 2, create immediately
+      submitTask(trimmed, 0);
+    } else {
+      setPhase("selecting");
+    }
   }
 
-  // Cycle through domains on dot click
-  function cycleDomain() {
-    if (domains.length === 0) return;
-    if (!domainId) {
-      setDomainId(domains[0].id);
-    } else {
-      const idx = domains.findIndex((d) => d.id === domainId);
-      if (idx === domains.length - 1) {
-        setDomainId(undefined);
-      } else {
-        setDomainId(domains[idx + 1].id);
+  function handleChipKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (phase !== "selecting") return;
+
+    switch (e.key) {
+      case "ArrowRight":
+      case "Tab": {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev + 1) % optionCount);
+        break;
+      }
+      case "ArrowLeft": {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev - 1 + optionCount) % optionCount);
+        break;
+      }
+      case "Enter": {
+        e.preventDefault();
+        submitTask(text.trim(), selectedIndex);
+        break;
+      }
+      case "Escape": {
+        e.preventDefault();
+        // Skip domain, create with no domain
+        submitTask(text.trim(), 0);
+        break;
       }
     }
   }
 
-  const activeDomain = domains.find((d) => d.id === domainId);
+  // Focus chip container when entering Phase 2
+  useEffect(() => {
+    if (phase === "selecting") {
+      chipContainerRef.current?.focus();
+    }
+  }, [phase]);
+
+  const isDisabled = phase === "submitting";
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center gap-2 rounded-lg bg-bg-card border border-border px-3 py-2.5 my-2">
-      {domains.length > 0 ? (
-        <button
-          type="button"
-          onClick={cycleDomain}
-          className="shrink-0 flex items-center gap-1.5 px-2 py-1 rounded-full border border-border hover:border-text-secondary transition-colors"
-          title={activeDomain ? `${activeDomain.name} (click to change)` : "Click to set domain"}
+    <div className="rounded-lg bg-bg-card border border-border px-3 py-2.5 my-2">
+      {/* Phase 1: Text input */}
+      <div className="flex items-center gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Add a task..."
+          maxLength={500}
+          disabled={isDisabled || phase === "selecting"}
+          className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none disabled:opacity-50"
+        />
+        {phase === "typing" && text.length > 0 && (
+          <span className="text-xs text-text-muted shrink-0">{text.length}/500</span>
+        )}
+      </div>
+
+      {/* Phase 2: Domain chip selector */}
+      <div
+        className={`overflow-hidden transition-all duration-200 ease-out ${
+          phase === "selecting" ? "max-h-12 opacity-100 mt-2" : "max-h-0 opacity-0"
+        }`}
+      >
+        <div
+          ref={chipContainerRef}
+          tabIndex={phase === "selecting" ? 0 : -1}
+          onKeyDown={handleChipKeyDown}
+          className="flex items-center gap-1.5 outline-none"
+          role="listbox"
+          aria-label="Select a domain"
         >
-          {activeDomain ? (
-            <span
-              className="h-2.5 w-2.5 rounded-full"
-              style={{ backgroundColor: activeDomain.color }}
-            />
-          ) : (
-            <span className="h-2.5 w-2.5 rounded-full border border-text-muted" />
-          )}
-          <span className="text-xs text-text-muted">
-            {activeDomain ? activeDomain.name : "Domain"}
+          {/* "None" option */}
+          <button
+            type="button"
+            tabIndex={-1}
+            onClick={() => {
+              setSelectedIndex(0);
+              submitTask(text.trim(), 0);
+            }}
+            className={`shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs transition-all ${
+              selectedIndex === 0
+                ? "bg-text-muted/20 text-text-primary border border-text-secondary"
+                : "text-text-muted border border-border hover:border-text-muted"
+            }`}
+            role="option"
+            aria-selected={selectedIndex === 0}
+          >
+            <span className="h-2 w-2 rounded-full border border-text-muted" />
+            None
+          </button>
+
+          {/* Domain options */}
+          {domains.map((domain, i) => {
+            const optIndex = i + 1;
+            const isActive = selectedIndex === optIndex;
+            return (
+              <button
+                key={domain.id}
+                type="button"
+                tabIndex={-1}
+                onClick={() => {
+                  setSelectedIndex(optIndex);
+                  submitTask(text.trim(), optIndex);
+                }}
+                className={`shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs transition-all ${
+                  isActive
+                    ? "bg-text-muted/20 text-text-primary border border-text-secondary"
+                    : "text-text-muted border border-border hover:border-text-muted"
+                }`}
+                role="option"
+                aria-selected={isActive}
+              >
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: domain.color }}
+                />
+                {domain.name}
+              </button>
+            );
+          })}
+
+          <span className="text-xs text-text-muted ml-1">
+            ← → then Enter
           </span>
-        </button>
-      ) : (
-        <a
-          href="/settings"
-          className="shrink-0 flex items-center gap-1 px-2 py-1 rounded-full border border-dashed border-border text-xs text-text-muted hover:border-text-secondary hover:text-text-secondary transition-colors"
-          title="Create domains in Settings"
-        >
-          <span className="h-2.5 w-2.5 rounded-full border border-text-muted" />
-          Domains
-        </a>
-      )}
-      <input
-        type="text"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder="Add a task..."
-        maxLength={500}
-        className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none"
-      />
-      {text.length > 0 && (
-        <span className="text-xs text-text-muted shrink-0">{text.length}/500</span>
-      )}
-    </form>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Closes #101

## Summary
Redesigns `TaskInput` from a single-phase form into a two-phase keyboard-first flow:

- **Phase 1:** Type task name → Enter
- **Phase 2:** Domain chips appear inline → Arrow keys cycle → Enter confirms (or Escape skips)
- Single API call after Phase 2 — task is NOT created on first Enter
- 0 domains = Phase 2 skipped, single Enter creates immediately
- "None" is default position — Enter+Enter = no domain (zero friction for skippers)

## Changes
- `frontend/src/components/task-input.tsx` — full redesign (162 lines replacing 62)

## How it works
State machine: `typing` → `selecting` → `submitting` → `typing`

- Phase transition animates via `max-h` + `opacity` CSS transition (200ms ease-out)
- Chip container gets focus in Phase 2, handles ArrowLeft/Right/Tab/Enter/Escape
- Clicking a chip directly selects + submits in one action
- Container height is stable (chips in hidden overflow, not conditionally rendered)

## Test plan
- [ ] Type task, Enter → domain chips appear with "None" highlighted
- [ ] Arrow right cycles through domains, wraps at end
- [ ] Arrow left cycles backward, wraps at start
- [ ] Enter on a domain creates task with that domain, refocuses input
- [ ] Escape creates task with no domain, refocuses input
- [ ] Enter+Enter rapid-fire = task with no domain
- [ ] With 0 domains: single Enter creates task immediately
- [ ] Click on a domain chip selects + creates
- [ ] Tab cycles forward (accessibility)
- [ ] Loading state prevents double-submit
- [ ] Character counter shows during Phase 1
- [ ] No height jump between phases
- [ ] Works on Today, Soon, Later, Someday pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)