### PR TITLE
feat: add global N keyboard shortcut to focus task input (#102)

### DIFF
--- a/frontend/src/app/(app)/bucket/[b]/page.tsx
+++ b/frontend/src/app/(app)/bucket/[b]/page.tsx
@@ -6,6 +6,8 @@ import type { Task, Domain, BucketType } from "@/lib/api-types";
 import { getTasks, getDomains, updateTask, deleteTask } from "@/lib/api";
 import { TaskItem } from "@/components/task-item";
 import { TaskInput } from "@/components/task-input";
+import type { TaskInputHandle } from "@/components/task-input";
+import { useGlobalShortcut } from "@/hooks/useGlobalShortcut";
 import { formatCompostAge } from "@/lib/utils";
 
 const VALID_BUCKETS = ["soon", "later", "someday"] as const;
@@ -27,6 +29,7 @@ export default function BucketPage() {
   const router = useRouter();
   const bucket = params.b as BucketType;
 
+  const taskInputRef = useRef<TaskInputHandle>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [domains, setDomains] = useState<Domain[]>([]);
   const [compostTasks, setCompostTasks] = useState<Task[]>([]);
@@ -41,6 +44,10 @@ export default function BucketPage() {
   const isValid = VALID_BUCKETS.includes(bucket as (typeof VALID_BUCKETS)[number]);
 
   const isSomeday = bucket === "someday";
+
+  useGlobalShortcut("n", useCallback(() => {
+    taskInputRef.current?.focus();
+  }, []));
 
   const refresh = useCallback(() => {
     if (!isValid) return;
@@ -141,7 +148,7 @@ export default function BucketPage() {
       </div>
 
       {/* Task input */}
-      <TaskInput bucket={bucket} domains={domains} onCreated={refresh} />
+      <TaskInput ref={taskInputRef} bucket={bucket} domains={domains} onCreated={refresh} />
 
       {/* Tasks */}
       <div className="flex-1 min-h-[120px]">

--- a/frontend/src/app/(app)/today/page.tsx
+++ b/frontend/src/app/(app)/today/page.tsx
@@ -1,22 +1,30 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import type { Task, Domain, NudgeStats, BucketType } from "@/lib/api-types";
 import { getTasks, getDomains, getNudge, setMIT } from "@/lib/api";
 import { TaskItem } from "@/components/task-item";
 import { TaskInput } from "@/components/task-input";
+import type { TaskInputHandle } from "@/components/task-input";
+import { useGlobalShortcut } from "@/hooks/useGlobalShortcut";
 import { cn } from "@/lib/utils";
 
 const BUCKET: BucketType = "today";
 
 export default function TodayPage() {
   const router = useRouter();
+  const taskInputRef = useRef<TaskInputHandle>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [domains, setDomains] = useState<Domain[]>([]);
   const [nudge, setNudge] = useState<NudgeStats | null>(null);
   const [domainFilter, setDomainFilter] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+
+  useGlobalShortcut("n", useCallback(() => {
+    taskInputRef.current?.focus();
+  }, []));
+
   const refresh = useCallback(() => {
     Promise.all([
       getTasks({ bucket: BUCKET }),
@@ -118,7 +126,7 @@ export default function TodayPage() {
       )}
 
       {/* Task input */}
-      <TaskInput bucket={BUCKET} domains={domains} onCreated={refresh} />
+      <TaskInput ref={taskInputRef} bucket={BUCKET} domains={domains} onCreated={refresh} />
 
       {/* Task list */}
       <div className="flex-1 min-h-[120px]">

--- a/frontend/src/components/task-input.tsx
+++ b/frontend/src/components/task-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
 import type { BucketType, Domain } from "@/lib/api-types";
 import { createTask } from "@/lib/api";
 
@@ -12,13 +12,21 @@ interface TaskInputProps {
   onCreated: () => void;
 }
 
-export function TaskInput({ bucket, domains, onCreated }: TaskInputProps) {
+export interface TaskInputHandle {
+  focus: () => void;
+}
+
+export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function TaskInput({ bucket, domains, onCreated }, ref) {
   const [text, setText] = useState("");
   const [phase, setPhase] = useState<Phase>("typing");
   // Index into [undefined, ...domains] where undefined = "None"
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const chipContainerRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => inputRef.current?.focus(),
+  }));
 
   const hasDomains = domains.length > 0;
   // Options: [undefined (None), domain0, domain1, ...]
@@ -187,4 +195,4 @@ export function TaskInput({ bucket, domains, onCreated }: TaskInputProps) {
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/hooks/useGlobalShortcut.ts
+++ b/frontend/src/hooks/useGlobalShortcut.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+/**
+ * Registers a global keyboard shortcut that only fires when no
+ * input, textarea, or contenteditable element is focused.
+ */
+export function useGlobalShortcut(key: string, callback: () => void) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== key) return;
+
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      if ((e.target as HTMLElement)?.isContentEditable) return;
+
+      e.preventDefault();
+      callback();
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [key, callback]);
+}


### PR DESCRIPTION
Closes #102

## Summary
- New `useGlobalShortcut` hook — reusable, guards against firing in inputs/textareas/contenteditable
- `TaskInput` now exposes `focus()` via `forwardRef` + `useImperativeHandle`
- Press `N` on Today or any Bucket page to focus the task input

## Changes
- `frontend/src/hooks/useGlobalShortcut.ts` (new) — 23-line reusable hook
- `frontend/src/components/task-input.tsx` — add forwardRef + imperative handle
- `frontend/src/app/(app)/today/page.tsx` — wire up hook
- `frontend/src/app/(app)/bucket/[b]/page.tsx` — wire up hook

## Test plan
- [ ] On Today page, press N — task input gets focus
- [ ] On Soon/Later/Someday pages, press N — task input gets focus
- [ ] While editing a task (input focused), press N — nothing happens (no conflict)
- [ ] While typing in task input, press N — types the letter N normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)