### PR TITLE
fix: refocus text input after two-phase task creation

### DIFF
--- a/frontend/src/components/task-input.tsx
+++ b/frontend/src/components/task-input.tsx
@@ -32,12 +32,13 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
   // Options: [undefined (None), domain0, domain1, ...]
   const optionCount = domains.length + 1;
 
+  const [shouldRefocus, setShouldRefocus] = useState(false);
+
   const resetToTyping = useCallback(() => {
     setText("");
     setSelectedIndex(0);
     setPhase("typing");
-    // Focus input on next tick after state update
-    setTimeout(() => inputRef.current?.focus(), 0);
+    setShouldRefocus(true);
   }, []);
 
   const submitTask = useCallback(async (taskText: string, domainIndex: number) => {
@@ -101,6 +102,14 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
       chipContainerRef.current?.focus();
     }
   }, [phase]);
+
+  // Refocus text input after task creation (waits for React to re-enable the input)
+  useEffect(() => {
+    if (shouldRefocus && phase === "typing") {
+      inputRef.current?.focus();
+      setShouldRefocus(false);
+    }
+  }, [shouldRefocus, phase]);
 
   const isDisabled = phase === "submitting";
 


### PR DESCRIPTION
## Summary
After creating a task via the two-phase flow (Enter → domain select → Enter), the text input wasn't regaining focus. The `setTimeout(0)` approach raced with React's re-render — the input was still `disabled` when `focus()` fired.

**Fix:** Replace setTimeout with a `useEffect` that watches for `shouldRefocus + phase === "typing"`, guaranteeing React has re-enabled the input before focusing.

## Test plan
- [ ] Type task → Enter → select domain → Enter → cursor is in the text input, ready for next task
- [ ] Type task → Enter → Escape → cursor is in the text input
- [ ] Rapid-fire: create 3 tasks in a row without touching the mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)