### PR TITLE
fix: change wind-down confirm button from Today to Tomorrow

### DIFF
--- a/frontend/src/components/triage-card.tsx
+++ b/frontend/src/components/triage-card.tsx
@@ -11,9 +11,10 @@ interface TriageCardProps {
   progress: { current: number; total: number };
   onAction: (result: TriageResult) => void;
   showHints?: boolean;
+  isWinddown?: boolean;
 }
 
-export function TriageCard({ task, progress, onAction, showHints = false }: TriageCardProps) {
+export function TriageCard({ task, progress, onAction, showHints = false, isWinddown = false }: TriageCardProps) {
   const [rewriteMode, setRewriteMode] = useState(false);
   const [rewriteText, setRewriteText] = useState(task.text);
   const [loading, setLoading] = useState(false);
@@ -130,8 +131,8 @@ export function TriageCard({ task, progress, onAction, showHints = false }: Tria
       {/* Action buttons — row 1: bucket choices */}
       <div className="grid grid-cols-4 gap-2 w-full">
         <ActionButton
-          label="Today"
-          hint={showHints ? "do it today" : undefined}
+          label={isWinddown ? "Tomorrow" : "Today"}
+          hint={showHints ? (isWinddown ? "first thing" : "do it today") : undefined}
           onClick={() => handleAction("confirm")}
           loading={loading}
           className="bg-accent-green/15 text-accent-green hover:bg-accent-green/25"

--- a/frontend/src/components/winddown-modal.tsx
+++ b/frontend/src/components/winddown-modal.tsx
@@ -163,6 +163,7 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
           task={task}
           progress={{ current: currentIndex + 1, total: tasks.length }}
           onAction={handleAction}
+          isWinddown
         />
       </RitualOverlay>
     );


### PR DESCRIPTION
## Summary
During wind-down, the confirm button said "Today" — but the user is closing out the day. Changed to "Tomorrow" with hint "first thing". Morning triage is unchanged.

## Changes
- `triage-card.tsx` — new `isWinddown` prop, conditional label/hint
- `winddown-modal.tsx` — pass `isWinddown` to TriageCard

## Test plan
- [ ] Morning triage: confirm button still says "Today" with hint "do it today"
- [ ] Wind-down: confirm button says "Tomorrow" with hint "first thing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)