### PR TITLE
fix: visible MIT indicator + triage re-check on stale tabs

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -92,12 +92,10 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   }, [pathname, router, skipGates]);
 
   // Triage gate: open modal if triage needed (only after onboarding confirmed)
-  useEffect(() => {
+  function checkTriage() {
     if (skipGates || !onboardingChecked) return;
-    let cancelled = false;
     getTriageQueue()
       .then((q) => {
-        if (cancelled) return;
         if (!q.triage_complete && q.tasks.length > 0) {
           setTriageQueue(q);
           setShowTriageModal(true);
@@ -105,12 +103,25 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         setTriageChecked(true);
       })
       .catch((err) => {
-        if (cancelled) return;
         console.error("Triage check failed:", err);
         setTriageChecked(true);
       });
-    return () => { cancelled = true; };
-  }, [pathname, router, skipGates, onboardingChecked]);
+  }
+
+  useEffect(() => {
+    checkTriage();
+  }, [pathname, skipGates, onboardingChecked]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-check triage when a stale tab becomes visible again
+  useEffect(() => {
+    function handleVisibility() {
+      if (document.visibilityState === "visible") {
+        checkTriage();
+      }
+    }
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }); // no deps — always uses latest skipGates/onboardingChecked via closure
 
   const showContent = skipGates || (onboardingChecked && triageChecked);
   const hideNav = pathname === "/onboarding";

--- a/frontend/src/components/task-item.tsx
+++ b/frontend/src/components/task-item.tsx
@@ -253,7 +253,7 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
     <div className={cn("group", isComplete && "opacity-40")}>
       <div className={cn(
         "flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-bg-hover transition-colors",
-        isMIT && "border-l-2 border-accent-blue",
+        isMIT && "bg-accent-blue/8 border border-accent-blue/20",
       )}>
         {/* Complete checkbox */}
         <button
@@ -329,6 +329,13 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
           >
             {task.text}
           </button>
+        )}
+
+        {/* MIT label */}
+        {isMIT && !isComplete && (
+          <span className="shrink-0 text-[10px] font-medium text-accent-blue/70 uppercase tracking-wider">
+            Most important
+          </span>
         )}
 
         {/* Edit button (hover affordance for tasks with children) */}


### PR DESCRIPTION
## Summary
Two fixes from real usage:

**1. MIT indicator is now visible**
- Old: `border-l-2 border-accent-blue` — invisible in dark mode
- New: Blue-tinted background (`bg-accent-blue/8`), subtle border (`border-accent-blue/20`), and a "MOST IMPORTANT" label in small caps next to the task text

**2. Stale tab re-triggers triage**
- Old: Triage check only ran on page load / navigation. A tab left open overnight wouldn't trigger triage the next morning.
- New: `visibilitychange` listener re-checks triage when tab becomes visible again.

## Changes
- `frontend/src/components/task-item.tsx` — MIT visual treatment + label
- `frontend/src/app/(app)/layout.tsx` — extract `checkTriage()`, add visibilitychange listener

## Test plan
- [ ] Set an MIT during triage — verify it shows blue background + "Most important" label on Today page
- [ ] Complete the MIT task — label disappears, task moves to completed section
- [ ] Leave tab open, wait (or simulate by navigating away and back) — triage should re-check
- [ ] On a non-triage page (settings), visibilitychange should not trigger triage check

🤖 Generated with [Claude Code](https://claude.com/claude-code)