### PR TITLE
fix: eliminate flash of dark mode on hard refresh (#110)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -44,6 +44,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("theme");if(t==="light")document.documentElement.classList.add("light")}catch(e){}})()`,
+          }}
+        />
+      </head>
       <body className="min-h-screen antialiased">
         <ThemeProvider>{children}</ThemeProvider>
       </body>

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -16,16 +16,16 @@ export function useTheme() {
   return useContext(ThemeContext);
 }
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("dark");
+function getInitialTheme(): Theme {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") return stored;
+  }
+  return "dark";
+}
 
-  useEffect(() => {
-    const stored = localStorage.getItem("theme") as Theme | null;
-    if (stored === "light" || stored === "dark") {
-      setTheme(stored);
-      document.documentElement.classList.toggle("light", stored === "light");
-    }
-  }, []);
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
   function toggle() {
     const next = theme === "dark" ? "light" : "dark";


### PR DESCRIPTION
## Summary
- Add blocking `<script>` in `<head>` to apply `light` class from localStorage before first paint
- Initialize `ThemeProvider` state from localStorage instead of always defaulting to `"dark"`
- Eliminates FODT (flash of dark theme) on hard refresh when user has light mode selected

Closes #110

## Test plan
- [ ] Set theme to light mode, hard refresh → no dark flash
- [ ] Set theme to dark mode, hard refresh → stays dark, no flash
- [ ] Toggle theme in settings → still works correctly
- [ ] Fresh browser (no localStorage) → defaults to dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)