### PR TITLE
fix: increase proxy timeout for streaming chat

### DIFF
--- a/frontend/src/app/api/[...proxy]/route.ts
+++ b/frontend/src/app/api/[...proxy]/route.ts
@@ -36,11 +36,15 @@ async function handler(
       headers["Content-Type"] = "application/json";
     }
 
+    // Streaming endpoints (chat) need a longer timeout
+    const isStream = path.includes("/stream");
+    const timeout = isStream ? 120000 : 15000;
+
     const res = await fetch(url.toString(), {
       method: req.method,
       headers,
       body: req.method !== "GET" && req.method !== "DELETE" ? await req.text() : undefined,
-      signal: AbortSignal.timeout(15000),
+      signal: AbortSignal.timeout(timeout),
     });
 
     // Stream the response back


### PR DESCRIPTION
## Summary
- Chat streaming was failing with "Request failed" because the proxy's 15s timeout was too short for Anthropic API responses
- Streaming endpoints now get 120s timeout, all others keep 15s

## Test plan
- [ ] Send a chat message and verify streaming response works

🤖 Generated with [Claude Code](https://claude.com/claude-code)