### PR TITLE
fix: clarify skip triage button label

### DIFF
--- a/frontend/src/components/triage-modal.tsx
+++ b/frontend/src/components/triage-modal.tsx
@@ -164,7 +164,7 @@ export function TriageModal({ onComplete, initialQueue }: TriageModalProps) {
       onClick={onComplete}
       className="text-xs text-text-muted hover:text-text-secondary transition-colors"
     >
-      Skip for now
+      Skip triage
     </button>
   );
 


### PR DESCRIPTION
## Summary
- Changes "Skip for now" → "Skip triage" to make it clear you're skipping the whole triage, not one task

🤖 Generated with [Claude Code](https://claude.com/claude-code)