### PR TITLE
Add day stats to wind-down intro

### DIFF
--- a/frontend/src/components/winddown-modal.tsx
+++ b/frontend/src/components/winddown-modal.tsx
@@ -17,6 +17,47 @@ interface ActionTally {
 
 const emptyTally: ActionTally = { kept: 0, deferred: 0, done: 0, killed: 0 };
 
+function DayStats({
+  completed,
+  total,
+  average,
+  mitCompleted,
+}: {
+  completed: number;
+  total: number;
+  average: number;
+  mitCompleted: boolean | null;
+}) {
+  return (
+    <div className="space-y-2">
+      {mitCompleted === true && (
+        <p className="text-sm text-accent-green">
+          You finished your most important task.
+        </p>
+      )}
+      {mitCompleted === false && (
+        <p className="text-sm text-accent-amber">
+          Your most important task is still open.
+        </p>
+      )}
+      {total > 0 && (
+        <p className="text-sm text-text-secondary">
+          You completed <span className="text-text-primary font-medium">{completed} of {total}</span> task{total !== 1 ? "s" : ""} today.
+        </p>
+      )}
+      {average > 0 && total > 0 && (
+        <p className="text-sm text-text-muted">
+          {completed > average
+            ? `Above your usual ~${average}.`
+            : completed === average
+              ? `Right at your usual ~${average}.`
+              : `A lighter day than your usual ~${average}.`}
+        </p>
+      )}
+    </div>
+  );
+}
+
 interface WinddownModalProps {
   onComplete: () => void;
 }
@@ -97,42 +138,6 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
   const added = nudge?.today_count ?? 0;
   const average = Math.round(nudge?.average_completed ?? 0);
 
-  function DayStats({ total }: { total: number }) {
-    return (
-      <div className="space-y-2">
-        {/* MIT status */}
-        {mitCompleted === true && (
-          <p className="text-sm text-accent-green">
-            You finished your most important task.
-          </p>
-        )}
-        {mitCompleted === false && (
-          <p className="text-sm text-accent-amber">
-            Your most important task is still open.
-          </p>
-        )}
-
-        {/* Completion ratio */}
-        {total > 0 && (
-          <p className="text-sm text-text-secondary">
-            You completed <span className="text-text-primary font-medium">{completed} of {total}</span> task{total !== 1 ? "s" : ""} today.
-          </p>
-        )}
-
-        {/* Average comparison */}
-        {average > 0 && total > 0 && (
-          <p className="text-sm text-text-muted">
-            {completed > average
-              ? `Above your usual ~${average}.`
-              : completed === average
-                ? `Right at your usual ~${average}.`
-                : `A lighter day than your usual ~${average}.`}
-          </p>
-        )}
-      </div>
-    );
-  }
-
   // --- Empty: nothing to wind down ---
   if (tasks.length === 0) {
     return (
@@ -142,7 +147,7 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
             <h2 className="text-xl font-semibold text-text-primary">Today is clear</h2>
             {added > 0 ? (
               <>
-                <DayStats total={added} />
+                <DayStats completed={completed} total={added} average={average} mitCompleted={mitCompleted} />
                 <p className="text-xs text-text-muted">Everything&apos;s been handled.</p>
               </>
             ) : (
@@ -169,7 +174,7 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
         <div className="flex flex-col items-center gap-6 px-4 w-full max-w-lg mx-auto">
           <div className="w-full rounded-2xl bg-bg-card border border-border p-6 space-y-4 text-center">
             <h2 className="text-xl font-semibold text-text-primary">Review my day</h2>
-            <DayStats total={total} />
+            <DayStats completed={completed} total={total} average={average} mitCompleted={mitCompleted} />
             {remaining > 0 && (
               <p className="text-sm text-text-muted">
                 {remaining} task{remaining !== 1 ? "s" : ""} still open &mdash; where should {remaining === 1 ? "it" : "they"} go?


### PR DESCRIPTION
Closes #140

## Summary
- MIT completion status: green "finished your most important task" / amber "still open" / hidden if no MIT
- Completion ratio: "X of Y tasks" (existing, preserved)
- Average comparison: "Above your usual ~N" / "Lighter day" / hidden for new users
- Shared `DayStats` component used in both intro and empty wind-down states
- No new backend work — all data from existing `getWinddown()` + `getNudge()`

## Test plan
- [x] Frontend builds
- [x] MIT status shown when MIT set + completed
- [x] MIT status shown when MIT set + not completed  
- [x] MIT status hidden when no MIT set (null)
- [x] Average comparison hidden for new users (0 average)
- [x] Empty wind-down (all tasks done) shows same stats
- [x] Tone is reflective, not gamified

🤖 Generated with [Claude Code](https://claude.com/claude-code)