### PR TITLE
Remove 'You usually finish' nudge from Today view

### DIFF
--- a/frontend/src/app/(app)/today/page.tsx
+++ b/frontend/src/app/(app)/today/page.tsx
@@ -221,15 +221,6 @@ export default function TodayPage() {
               {nudge.today_count === 1 ? "task" : "tasks"} today
             </span>
           </div>
-          {Math.round(nudge.average_completed) > 0 ? (
-            <p className="mt-1 text-sm text-accent-amber">
-              You usually finish ~{Math.round(nudge.average_completed)}
-            </p>
-          ) : (
-            <p className="mt-1 text-sm text-text-muted">
-              Let&apos;s see what you can do.
-            </p>
-          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Remove the "You usually finish ~N" / "Let's see what you can do" subtitle from the Today nudge card
- Keep the task count ("7 tasks today") which is useful without being judgmental

Closes: N/A (UX improvement, no issue)

## Test plan
- [ ] Today view shows task count without subtitle
- [ ] Nudge card still has gradient background and proper spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)