### PR TITLE
Add task notes (model, API, TaskItem UI, TriageCard UI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ __pycache__/
 # Editor
 .vscode/
 .idea/
+
+# AI workspace
+.llm/
+.context/

--- a/backend/alembic/versions/2026_04_10_0053-2fd06db2a9d8_add_notes_to_tasks.py
+++ b/backend/alembic/versions/2026_04_10_0053-2fd06db2a9d8_add_notes_to_tasks.py
@@ -1,0 +1,28 @@
+"""add notes to tasks
+
+Revision ID: 2fd06db2a9d8
+Revises: 1bd69e02305b
+Create Date: 2026-04-10 00:53:54.016515
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2fd06db2a9d8'
+down_revision: Union[str, Sequence[str], None] = '1bd69e02305b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add notes TEXT NULL column to tasks table."""
+    op.add_column('tasks', sa.Column('notes', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove notes column from tasks table."""
+    op.drop_column('tasks', 'notes')

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -28,6 +28,7 @@ def _to_response(task, mit_task_id: uuid.UUID | None = None) -> TaskResponse:
         status=task.status,
         reschedule_count=task.reschedule_count,
         triaged_at=task.triaged_at,
+        notes=task.notes,
         domain=DomainBrief(id=task.domain.id, name=task.domain.name, color=task.domain.color)
         if task.domain
         else None,
@@ -88,6 +89,7 @@ def create_task(
         bucket=body.bucket,
         domain_id=body.domain_id,
         parent_id=body.parent_id,
+        notes=body.notes,
         skip_triage_stamp=skip_stamp,
     )
     # Reload with relationships for response
@@ -121,6 +123,8 @@ def update_task(
         kwargs["domain_id"] = body.domain_id
     if body.status is not None:
         kwargs["status"] = body.status
+    if "notes" in body.model_fields_set:
+        kwargs["notes"] = body.notes
     task = task_service.update_task(db, user_id, task_id, **kwargs)
     return _to_response(task)
 

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -17,6 +17,7 @@ class Task(SQLModel, table=True):
     bucket: BucketType = Field(sa_column=Column(String, nullable=False, default="today"))
     status: TaskStatus = Field(sa_column=Column(String, nullable=False, default="pending"))
     reschedule_count: int = Field(default=0)
+    notes: str | None = Field(default=None, max_length=2000)
     position: int | None = Field(default=None)
     triaged_at: date | None = Field(default=None)
 

--- a/backend/app/schemas/task_schemas.py
+++ b/backend/app/schemas/task_schemas.py
@@ -11,6 +11,7 @@ class TaskCreate(BaseModel):
     bucket: BucketType = BucketType.today
     domain_id: uuid.UUID | None = None
     parent_id: uuid.UUID | None = None
+    notes: str | None = None
     skip_triage_stamp: bool = False
 
 
@@ -19,6 +20,7 @@ class TaskUpdate(BaseModel):
     bucket: BucketType | None = None
     domain_id: uuid.UUID | None = None
     status: TaskStatus | None = None
+    notes: str | None = None
 
 
 class ReorderRequest(BaseModel):
@@ -54,6 +56,7 @@ class TaskResponse(BaseModel):
     status: TaskStatus
     reschedule_count: int
     triaged_at: date | None
+    notes: str | None
     domain: DomainBrief | None
     parent_id: uuid.UUID | None
     children: list[SubTaskResponse]

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -29,6 +29,7 @@ def create_task(
     bucket: BucketType = BucketType.today,
     domain_id: uuid.UUID | None = None,
     parent_id: uuid.UUID | None = None,
+    notes: str | None = None,
     skip_triage_stamp: bool = False,
 ) -> Task:
     if len(text) > 500:
@@ -45,8 +46,26 @@ def create_task(
             status_code=422,
         )
 
+    # Normalize notes: empty string → None
+    if notes is not None:
+        notes = notes.strip() or None
+
+    # Validate notes length
+    if notes is not None and len(notes) > 2000:
+        raise AppError(
+            code="validation_error",
+            message="Notes must be 2000 characters or fewer",
+            status_code=422,
+        )
+
     # If sub-task, validate parent and inherit bucket/domain
     if parent_id is not None:
+        if notes is not None:
+            raise AppError(
+                code="validation_error",
+                message="Sub-tasks cannot have notes",
+                status_code=400,
+            )
         parent = db.get(Task, parent_id)
         if parent is None or parent.user_id != user_id:
             raise NotFoundError("Parent task not found")
@@ -79,6 +98,7 @@ def create_task(
         status=TaskStatus.pending,
         domain_id=domain_id,
         parent_id=parent_id,
+        notes=notes,
         position=position,
         triaged_at=None if skip_triage_stamp else date.today(),
     )
@@ -139,8 +159,27 @@ def update_task(
     bucket: BucketType | None = None,
     domain_id: uuid.UUID | None | object = _UNSET,
     status: TaskStatus | None = None,
+    notes: str | None | object = _UNSET,
 ) -> Task:
     task = get_task(db, user_id, task_id)
+
+    if notes is not _UNSET:
+        if task.parent_id is not None and notes is not None and notes != "":
+            raise AppError(
+                code="validation_error",
+                message="Sub-tasks cannot have notes",
+                status_code=400,
+            )
+        # Normalize empty string → None
+        if isinstance(notes, str):
+            notes = notes.strip() or None
+        if notes is not None and len(notes) > 2000:
+            raise AppError(
+                code="validation_error",
+                message="Notes must be 2000 characters or fewer",
+                status_code=422,
+            )
+        task.notes = notes
 
     if text is not None:
         if len(text) > 500:

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -164,15 +164,15 @@ def update_task(
     task = get_task(db, user_id, task_id)
 
     if notes is not _UNSET:
-        if task.parent_id is not None and notes is not None and notes != "":
+        # Normalize empty string → None first
+        if isinstance(notes, str):
+            notes = notes.strip() or None
+        if task.parent_id is not None and notes is not None:
             raise AppError(
                 code="validation_error",
                 message="Sub-tasks cannot have notes",
                 status_code=400,
             )
-        # Normalize empty string → None
-        if isinstance(notes, str):
-            notes = notes.strip() or None
         if notes is not None and len(notes) > 2000:
             raise AppError(
                 code="validation_error",

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -310,3 +310,91 @@ class TestReorderTasks:
 
         r = client.patch("/tasks/reorder", json={"task_ids": [str(t.id)]})
         assert r.status_code == 400
+
+
+class TestTaskNotes:
+    def test_create_task_with_notes(self, client, test_user):
+        """Top-level task can be created with notes."""
+        r = client.post("/tasks", json={"text": "Task with note", "notes": "Some context"})
+        assert r.status_code == 201
+        assert r.json()["notes"] == "Some context"
+
+    def test_create_task_without_notes(self, client, test_user):
+        """Tasks without notes return null."""
+        r = client.post("/tasks", json={"text": "No note"})
+        assert r.status_code == 201
+        assert r.json()["notes"] is None
+
+    def test_create_subtask_with_notes_rejected(self, client, test_user, test_tasks):
+        """Sub-tasks cannot have notes — returns 400."""
+        parent = test_tasks[0]
+        r = client.post(
+            "/tasks",
+            json={"text": "Child", "parent_id": str(parent.id), "notes": "Not allowed"},
+        )
+        assert r.status_code == 400
+
+    def test_update_task_set_notes(self, client, test_user, test_tasks):
+        """Can set notes on an existing top-level task."""
+        task = test_tasks[0]
+        r = client.patch(f"/tasks/{task.id}", json={"notes": "Added later"})
+        assert r.status_code == 200
+        assert r.json()["notes"] == "Added later"
+
+    def test_update_task_clear_notes_with_empty_string(self, client, test_user, test_tasks):
+        """Sending empty string clears notes (stored as NULL)."""
+        task = test_tasks[0]
+        # First set a note
+        client.patch(f"/tasks/{task.id}", json={"notes": "Temporary"})
+        # Then clear it
+        r = client.patch(f"/tasks/{task.id}", json={"notes": ""})
+        assert r.status_code == 200
+        assert r.json()["notes"] is None
+
+    def test_update_task_clear_notes_with_null(self, client, test_user, test_tasks):
+        """Sending null clears notes."""
+        task = test_tasks[0]
+        client.patch(f"/tasks/{task.id}", json={"notes": "Temporary"})
+        r = client.patch(f"/tasks/{task.id}", json={"notes": None})
+        assert r.status_code == 200
+        assert r.json()["notes"] is None
+
+    def test_update_subtask_with_notes_rejected(self, client, db, test_user, test_tasks):
+        """Cannot set notes on a sub-task via update — returns 400."""
+        parent = test_tasks[0]
+        child = Task(
+            user_id=test_user.id,
+            text="Child",
+            bucket=BucketType.today,
+            parent_id=parent.id,
+        )
+        db.add(child)
+        db.flush()
+
+        r = client.patch(f"/tasks/{child.id}", json={"notes": "Not allowed"})
+        assert r.status_code == 400
+
+    def test_notes_too_long_rejected(self, client, test_user):
+        """Notes over 2000 chars are rejected with 422."""
+        r = client.post("/tasks", json={"text": "Task", "notes": "x" * 2001})
+        assert r.status_code == 422
+
+    def test_notes_empty_string_normalized_to_null_on_create(self, client, test_user):
+        """Empty string notes on create stored as NULL."""
+        r = client.post("/tasks", json={"text": "Task", "notes": ""})
+        assert r.status_code == 201
+        assert r.json()["notes"] is None
+
+    def test_notes_whitespace_normalized_to_null(self, client, test_user):
+        """Whitespace-only notes normalized to NULL."""
+        r = client.post("/tasks", json={"text": "Task", "notes": "   "})
+        assert r.status_code == 201
+        assert r.json()["notes"] is None
+
+    def test_notes_preserved_on_unrelated_update(self, client, test_user, test_tasks):
+        """Updating text doesn't wipe existing notes."""
+        task = test_tasks[0]
+        client.patch(f"/tasks/{task.id}", json={"notes": "Keep this"})
+        r = client.patch(f"/tasks/{task.id}", json={"text": "New text"})
+        assert r.status_code == 200
+        assert r.json()["notes"] == "Keep this"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -35,25 +35,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.84.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -313,24 +294,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -467,57 +430,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "jiter"
-version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
-    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
-    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
-    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
-    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
-    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
-    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
-    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
-    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
-    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
-    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
-    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
-    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
-    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
-    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
-    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
 ]
 
 [[package]]
@@ -922,15 +834,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
 name = "sqlalchemy"
 version = "2.0.46"
 source = { registry = "https://pypi.org/simple" }
@@ -1009,7 +912,6 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
-    { name = "anthropic" },
     { name = "bcrypt" },
     { name = "fastapi" },
     { name = "psycopg2-binary" },
@@ -1032,7 +934,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
-    { name = "anthropic", specifier = ">=0.40.0" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@types/bcrypt": "^6.0.0",
         "bcrypt": "^6.0.0",
         "jose": "^6.1.3",
+        "lucide-react": "^1.8.0",
         "next": "16.1.6",
         "next-auth": "^5.0.0-beta.30",
         "next-themes": "^0.4.6",
@@ -4976,6 +4977,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/bcrypt": "^6.0.0",
     "bcrypt": "^6.0.0",
     "jose": "^6.1.3",
+    "lucide-react": "^1.8.0",
     "next": "16.1.6",
     "next-auth": "^5.0.0-beta.30",
     "next-themes": "^0.4.6",

--- a/frontend/src/components/task-item.tsx
+++ b/frontend/src/components/task-item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { StickyNote } from "lucide-react";
 import type { Task, Domain, SubTask } from "@/lib/api-types";
 import { completeTask, createTask, deleteTask, updateTask } from "@/lib/api";
 import { formatAge, ageColor, cn } from "@/lib/utils";
@@ -136,8 +137,16 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
   const [subtaskText, setSubtaskText] = useState("");
   const [subtaskLoading, setSubtaskLoading] = useState(false);
   const subtaskInputRef = useRef<HTMLInputElement>(null);
+  const [noteExpanded, setNoteExpanded] = useState(false);
+  const [noteEditing, setNoteEditing] = useState(false);
+  const [noteDraft, setNoteDraft] = useState(task.notes ?? "");
+  const [noteSaving, setNoteSaving] = useState(false);
+  const [noteError, setNoteError] = useState<string | null>(null);
+  const noteTextareaRef = useRef<HTMLTextAreaElement>(null);
   const isComplete = task.status === "complete";
+  const isSubtask = !!task.parent_id;
   const hasChildren = task.children.length > 0;
+  const hasNote = !!task.notes;
   const completedChildren = task.children.filter((c) => c.status === "complete").length;
 
   useEffect(() => {
@@ -249,6 +258,55 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
     }
   }
 
+  function startNoteEdit() {
+    setNoteDraft(task.notes ?? "");
+    setNoteEditing(true);
+    setNoteExpanded(true);
+    setNoteError(null);
+  }
+
+  function cancelNoteEdit() {
+    setNoteDraft(task.notes ?? "");
+    setNoteEditing(false);
+    setNoteError(null);
+    if (!task.notes) setNoteExpanded(false);
+  }
+
+  const saveNote = useCallback(async () => {
+    if (noteSaving) return;
+    setNoteSaving(true);
+    setNoteError(null);
+    try {
+      await updateTask(task.id, { notes: noteDraft });
+      setNoteEditing(false);
+      if (!noteDraft.trim()) setNoteExpanded(false);
+      onMutate();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Failed to save note";
+      setNoteError(msg);
+      setNoteSaving(false);
+    }
+  }, [task.id, noteDraft, noteSaving, onMutate]);
+
+  function handleNoteKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      cancelNoteEdit();
+    } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      saveNote();
+    }
+  }
+
+  // Auto-resize textarea
+  useEffect(() => {
+    if (noteEditing && noteTextareaRef.current) {
+      noteTextareaRef.current.focus();
+      const ta = noteTextareaRef.current;
+      ta.style.height = "auto";
+      ta.style.height = ta.scrollHeight + "px";
+    }
+  }, [noteEditing]);
+
   return (
     <div className={cn("group", isComplete && "opacity-40")}>
       <div className={cn(
@@ -338,6 +396,17 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
           </span>
         )}
 
+        {/* Note indicator */}
+        {!isSubtask && hasNote && (
+          <button
+            onClick={() => setNoteExpanded(!noteExpanded)}
+            className="shrink-0 text-text-muted hover:text-text-secondary transition-colors"
+            title="View note"
+          >
+            <StickyNote className="h-3.5 w-3.5" />
+          </button>
+        )}
+
         {/* Edit button (hover affordance for tasks with children) */}
         {!isEditing && !isComplete && hasChildren && (
           <button
@@ -357,6 +426,17 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
             title="Set as most important task"
           >
             most important
+          </button>
+        )}
+
+        {/* Add note button (top-level tasks without notes) */}
+        {!isEditing && !isComplete && !isSubtask && !hasNote && (
+          <button
+            onClick={startNoteEdit}
+            className="shrink-0 hover-action text-text-muted hover:text-text-secondary"
+            title="Add note"
+          >
+            <StickyNote className="h-3.5 w-3.5" />
           </button>
         )}
 
@@ -400,6 +480,57 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
           ×
         </button>
       </div>
+
+      {/* Note expand/edit area */}
+      {!isSubtask && noteExpanded && (
+        <div className="ml-8 px-3 py-2">
+          {noteEditing ? (
+            <div className="space-y-2">
+              <textarea
+                ref={noteTextareaRef}
+                value={noteDraft}
+                onChange={(e) => {
+                  setNoteDraft(e.target.value);
+                  e.target.style.height = "auto";
+                  e.target.style.height = e.target.scrollHeight + "px";
+                }}
+                onKeyDown={handleNoteKeyDown}
+                maxLength={2000}
+                placeholder="Add a note..."
+                className="w-full bg-bg-input border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-accent-blue resize-none min-h-[60px]"
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={saveNote}
+                  disabled={noteSaving}
+                  className="text-xs px-2.5 py-1 rounded bg-accent-blue/15 text-accent-blue hover:bg-accent-blue/25 disabled:opacity-50 transition-colors"
+                >
+                  {noteSaving ? "Saving…" : "Save"}
+                </button>
+                <button
+                  onClick={cancelNoteEdit}
+                  className="text-xs px-2.5 py-1 rounded text-text-muted hover:text-text-secondary transition-colors"
+                >
+                  Cancel
+                </button>
+                <span className="text-[10px] text-text-muted ml-auto">
+                  {noteDraft.length}/2000
+                </span>
+              </div>
+              {noteError && (
+                <p className="text-xs text-accent-red">{noteError}</p>
+              )}
+            </div>
+          ) : (
+            <button
+              onClick={startNoteEdit}
+              className="text-sm text-text-secondary hover:text-text-primary text-left w-full whitespace-pre-wrap transition-colors"
+            >
+              {task.notes}
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Expanded subtasks + add subtask input */}
       {(expanded && hasChildren) || isAddingSubtask ? (

--- a/frontend/src/components/task-item.tsx
+++ b/frontend/src/components/task-item.tsx
@@ -279,6 +279,7 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
     try {
       await updateTask(task.id, { notes: noteDraft });
       setNoteEditing(false);
+      setNoteSaving(false);
       if (!noteDraft.trim()) setNoteExpanded(false);
       onMutate();
     } catch (err: unknown) {

--- a/frontend/src/components/triage-card.tsx
+++ b/frontend/src/components/triage-card.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { StickyNote } from "lucide-react";
 import type { Task, TriageAction, TriageResult, BucketType } from "@/lib/api-types";
-import { submitTriage } from "@/lib/api";
+import { submitTriage, updateTask } from "@/lib/api";
 import { DomainBadge } from "@/components/domain-badge";
 import { formatAge, cn } from "@/lib/utils";
 
@@ -20,8 +21,65 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
   const [loading, setLoading] = useState(false);
 
   const [rewriteDismissed, setRewriteDismissed] = useState(false);
+  const [noteExpanded, setNoteExpanded] = useState(false);
+  const [noteEditing, setNoteEditing] = useState(false);
+  const [noteDraft, setNoteDraft] = useState(task.notes ?? "");
+  const [noteSaving, setNoteSaving] = useState(false);
+  const [noteError, setNoteError] = useState<string | null>(null);
+  const [currentNotes, setCurrentNotes] = useState(task.notes);
+  const noteTextareaRef = useRef<HTMLTextAreaElement>(null);
   const showRewrite = task.reschedule_count >= 3 && !rewriteMode && !rewriteDismissed;
+  const hasNote = !!currentNotes;
   const completedChildren = task.children.filter((c) => c.status === "complete").length;
+
+  function startNoteEdit() {
+    setNoteDraft(currentNotes ?? "");
+    setNoteEditing(true);
+    setNoteExpanded(true);
+    setNoteError(null);
+  }
+
+  function cancelNoteEdit() {
+    setNoteDraft(currentNotes ?? "");
+    setNoteEditing(false);
+    setNoteError(null);
+    if (!currentNotes) setNoteExpanded(false);
+  }
+
+  const saveNote = useCallback(async () => {
+    if (noteSaving) return;
+    setNoteSaving(true);
+    setNoteError(null);
+    try {
+      const updated = await updateTask(task.id, { notes: noteDraft });
+      setCurrentNotes(updated.notes);
+      setNoteEditing(false);
+      setNoteSaving(false);
+      if (!noteDraft.trim()) setNoteExpanded(false);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Failed to save note";
+      setNoteError(msg);
+      setNoteSaving(false);
+    }
+  }, [task.id, noteDraft, noteSaving]);
+
+  function handleNoteKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      cancelNoteEdit();
+    } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      saveNote();
+    }
+  }
+
+  useEffect(() => {
+    if (noteEditing && noteTextareaRef.current) {
+      noteTextareaRef.current.focus();
+      const ta = noteTextareaRef.current;
+      ta.style.height = "auto";
+      ta.style.height = ta.scrollHeight + "px";
+    }
+  }, [noteEditing]);
 
   async function handleAction(action: TriageAction, bucket?: BucketType) {
     if (loading) return;
@@ -85,6 +143,75 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
             </span>
           )}
         </div>
+
+        {/* Note indicator + expand/edit */}
+        {hasNote && !noteExpanded && (
+          <button
+            onClick={() => setNoteExpanded(true)}
+            className="flex items-center gap-1.5 text-xs text-text-muted hover:text-text-secondary transition-colors"
+          >
+            <StickyNote className="h-3.5 w-3.5" />
+            <span>View note</span>
+          </button>
+        )}
+        {noteExpanded && (
+          <div className="space-y-2">
+            {noteEditing ? (
+              <>
+                <textarea
+                  ref={noteTextareaRef}
+                  value={noteDraft}
+                  onChange={(e) => {
+                    setNoteDraft(e.target.value);
+                    e.target.style.height = "auto";
+                    e.target.style.height = e.target.scrollHeight + "px";
+                  }}
+                  onKeyDown={handleNoteKeyDown}
+                  maxLength={2000}
+                  placeholder="Add a note..."
+                  className="w-full bg-bg-input border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-accent-blue resize-none min-h-[60px] max-h-[120px] overflow-y-auto"
+                />
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={saveNote}
+                    disabled={noteSaving}
+                    className="text-xs px-2.5 py-1 rounded bg-accent-blue/15 text-accent-blue hover:bg-accent-blue/25 disabled:opacity-50 transition-colors"
+                  >
+                    {noteSaving ? "Saving…" : "Save"}
+                  </button>
+                  <button
+                    onClick={cancelNoteEdit}
+                    className="text-xs px-2.5 py-1 rounded text-text-muted hover:text-text-secondary transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <span className="text-[10px] text-text-muted ml-auto">
+                    {noteDraft.length}/2000
+                  </span>
+                </div>
+                {noteError && (
+                  <p className="text-xs text-accent-red">{noteError}</p>
+                )}
+              </>
+            ) : (
+              <button
+                onClick={startNoteEdit}
+                className="text-sm text-text-secondary hover:text-text-primary text-left w-full whitespace-pre-wrap max-h-[120px] overflow-y-auto transition-colors"
+              >
+                {currentNotes}
+              </button>
+            )}
+          </div>
+        )}
+        {!hasNote && !noteExpanded && (
+          <button
+            onClick={startNoteEdit}
+            className="flex items-center gap-1.5 text-xs text-text-muted hover:text-text-secondary transition-colors"
+          >
+            <StickyNote className="h-3.5 w-3.5" />
+            <span>Add note</span>
+          </button>
+        )}
 
         {/* Sub-tasks preview */}
         {task.children.length > 0 && (

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -34,6 +34,7 @@ export interface Task {
   status: TaskStatus;
   reschedule_count: number;
   triaged_at: string | null;
+  notes: string | null;
   domain: DomainBrief | null;
   parent_id: string | null;
   children: SubTask[];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -72,7 +72,7 @@ export async function createTask(body: {
 
 export async function updateTask(
   id: string,
-  body: { text?: string; bucket?: BucketType; domain_id?: string | null; status?: TaskStatus },
+  body: { text?: string; bucket?: BucketType; domain_id?: string | null; status?: TaskStatus; notes?: string | null },
 ): Promise<Task> {
   return request<Task>(`tasks/${id}`, { method: "PATCH", body: JSON.stringify(body) });
 }


### PR DESCRIPTION
Closes #155, closes #156, closes #157

## Summary
- **Backend:** Alembic migration adds `notes TEXT NULL` to tasks, model/schema/service updated with 2000-char max, sub-task rejection (400), and empty→NULL normalization. 11 new tests.
- **TaskItem UI:** StickyNote indicator when note exists, tap to expand/read, tap text to edit inline. Auto-growing textarea with Save/Cancel, Cmd+Enter to save, Escape to cancel. Add-note affordance for tasks without notes. Not shown on sub-task rows.
- **TriageCard UI:** Same note behavior with max-height scroll so action buttons stay reachable on mobile. Uses local state so note saves don't trigger triage navigation.
- Adds `lucide-react` for the StickyNote icon.

## Test plan
- [x] Migration runs forward and backward cleanly
- [x] 11 new backend tests: create with notes, sub-task rejection, empty normalization, >2000 char rejection, update set/clear notes, unrelated update preserves notes
- [x] Full backend suite passes (160 tests)
- [x] Frontend type check clean
- [x] Frontend build succeeds
- [ ] Manual: create task with note, verify indicator appears
- [ ] Manual: tap indicator to expand, tap text to edit, save, verify persistence
- [ ] Manual: save empty note clears it
- [ ] Manual: triage card shows note and allows editing
- [ ] Manual: light/dark mode both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)