### PR TITLE
Remove nudge stats banner and average comparison

### DIFF
--- a/frontend/src/app/(app)/today/page.tsx
+++ b/frontend/src/app/(app)/today/page.tsx
@@ -17,8 +17,8 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import type { Task, Domain, NudgeStats, BucketType } from "@/lib/api-types";
-import { getTasks, getDomains, getNudge, setMIT, reorderTasks, updateTask } from "@/lib/api";
+import type { Task, Domain, BucketType } from "@/lib/api-types";
+import { getTasks, getDomains, setMIT, reorderTasks, updateTask } from "@/lib/api";
 import { TaskItem } from "@/components/task-item";
 import { SortableTaskItem } from "@/components/sortable-task-item";
 import { TaskInput } from "@/components/task-input";
@@ -32,7 +32,6 @@ export default function TodayPage() {
   const taskInputRef = useRef<TaskInputHandle>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [domains, setDomains] = useState<Domain[]>([]);
-  const [nudge, setNudge] = useState<NudgeStats | null>(null);
   const [domainFilter, setDomainFilter] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -59,11 +58,9 @@ export default function TodayPage() {
     Promise.all([
       getTasks({ bucket: BUCKET }),
       getDomains(),
-      getNudge(),
-    ]).then(([t, d, n]) => {
+    ]).then(([t, d]) => {
       setTasks(t);
       setDomains(d);
-      setNudge(n);
       setLoading(false);
     }).catch((err) => {
       console.error("Failed to load today:", err);
@@ -210,27 +207,6 @@ export default function TodayPage() {
 
   return (
     <div className="flex flex-col min-h-screen max-w-lg mx-auto px-4 py-6 gap-4">
-      {/* Nudge */}
-      {nudge && nudge.today_count > 0 && (
-        <div className="rounded-xl bg-gradient-to-r from-accent-blue/5 to-transparent px-5 py-5">
-          <div className="flex items-baseline gap-2">
-            <span className="text-3xl font-bold text-text-primary">{nudge.today_count}</span>
-            <span className="text-base text-text-secondary">
-              {nudge.today_count === 1 ? "task" : "tasks"} today
-            </span>
-          </div>
-          {Math.round(nudge.average_completed) > 0 ? (
-            <p className="mt-1 text-sm text-accent-amber">
-              You usually finish ~{Math.round(nudge.average_completed)}
-            </p>
-          ) : (
-            <p className="mt-1 text-sm text-text-muted">
-              Let&apos;s see what you can do.
-            </p>
-          )}
-        </div>
-      )}
-
       {/* Domain filters */}
       {domains.length > 0 && (
         <div className="flex items-center gap-2">

--- a/frontend/src/components/winddown-modal.tsx
+++ b/frontend/src/components/winddown-modal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { NudgeStats, Task, TriageAction } from "@/lib/api-types";
-import { getWinddown, getNudge } from "@/lib/api";
+import type { Task, TriageAction } from "@/lib/api-types";
+import { getWinddown } from "@/lib/api";
 import { TriageCard } from "@/components/triage-card";
 import { RitualOverlay } from "@/components/ritual-overlay";
 
@@ -17,54 +17,12 @@ interface ActionTally {
 
 const emptyTally: ActionTally = { kept: 0, deferred: 0, done: 0, killed: 0 };
 
-function DayStats({
-  completed,
-  total,
-  average,
-  mitCompleted,
-}: {
-  completed: number;
-  total: number;
-  average: number;
-  mitCompleted: boolean | null;
-}) {
-  return (
-    <div className="space-y-2">
-      {mitCompleted === true && (
-        <p className="text-sm text-accent-green">
-          You finished your most important task.
-        </p>
-      )}
-      {mitCompleted === false && (
-        <p className="text-sm text-accent-amber">
-          Your most important task is still open.
-        </p>
-      )}
-      {total > 0 && (
-        <p className="text-sm text-text-secondary">
-          You completed <span className="text-text-primary font-medium">{completed} of {total}</span> task{total !== 1 ? "s" : ""} today.
-        </p>
-      )}
-      {average > 0 && total > 0 && (
-        <p className="text-sm text-text-muted">
-          {completed > average
-            ? `Above your usual ~${average}.`
-            : completed === average
-              ? `Right at your usual ~${average}.`
-              : `A lighter day than your usual ~${average}.`}
-        </p>
-      )}
-    </div>
-  );
-}
-
 interface WinddownModalProps {
   onComplete: () => void;
 }
 
 export function WinddownModal({ onComplete }: WinddownModalProps) {
   const [tasks, setTasks] = useState<Task[]>([]);
-  const [nudge, setNudge] = useState<NudgeStats | null>(null);
   const [mitCompleted, setMitCompleted] = useState<boolean | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -73,11 +31,10 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
   const [tally, setTally] = useState<ActionTally>({ ...emptyTally });
 
   useEffect(() => {
-    Promise.all([getWinddown(), getNudge()])
-      .then(([w, n]) => {
+    getWinddown()
+      .then((w) => {
         setTasks(w.tasks);
         setMitCompleted(w.mit_completed);
-        setNudge(n);
         setLoading(false);
       })
       .catch((err) => {
@@ -133,11 +90,6 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
     );
   }
 
-  // Shared stats for intro and empty states
-  const completed = nudge?.completed_count ?? 0;
-  const added = nudge?.today_count ?? 0;
-  const average = Math.round(nudge?.average_completed ?? 0);
-
   // --- Empty: nothing to wind down ---
   if (tasks.length === 0) {
     return (
@@ -145,16 +97,14 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
         <div className="flex flex-col items-center justify-center gap-6 px-4 w-full max-w-md mx-auto">
           <div className="w-full rounded-2xl bg-bg-card border border-border p-6 space-y-4 text-center">
             <h2 className="text-xl font-semibold text-text-primary">Today is clear</h2>
-            {added > 0 ? (
-              <>
-                <DayStats completed={completed} total={added} average={average} mitCompleted={mitCompleted} />
-                <p className="text-xs text-text-muted">Everything&apos;s been handled.</p>
-              </>
-            ) : (
-              <p className="text-sm text-text-secondary leading-relaxed">
-                Nothing left to close out. Nice work.
+            {mitCompleted === true && (
+              <p className="text-sm text-accent-green">
+                You finished your most important task.
               </p>
             )}
+            <p className="text-sm text-text-secondary leading-relaxed">
+              Nothing left to close out. Nice work.
+            </p>
           </div>
           <button onClick={onComplete} className="text-sm text-accent-blue hover:underline">
             Close
@@ -167,14 +117,22 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
   // --- Intro: reflection before cards ---
   if (phase === "intro") {
     const remaining = tasks.length;
-    const total = completed + remaining;
 
     return (
       <RitualOverlay>
         <div className="flex flex-col items-center gap-6 px-4 w-full max-w-lg mx-auto">
           <div className="w-full rounded-2xl bg-bg-card border border-border p-6 space-y-4 text-center">
             <h2 className="text-xl font-semibold text-text-primary">Review my day</h2>
-            <DayStats completed={completed} total={total} average={average} mitCompleted={mitCompleted} />
+            {mitCompleted === true && (
+              <p className="text-sm text-accent-green">
+                You finished your most important task.
+              </p>
+            )}
+            {mitCompleted === false && (
+              <p className="text-sm text-accent-amber">
+                Your most important task is still open.
+              </p>
+            )}
             {remaining > 0 && (
               <p className="text-sm text-text-muted">
                 {remaining} task{remaining !== 1 ? "s" : ""} still open &mdash; where should {remaining === 1 ? "it" : "they"} go?

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -75,14 +75,6 @@ export interface BriefingResponse {
   calibration: string;
 }
 
-// Stats
-export interface NudgeStats {
-  today_count: number;
-  completed_count: number;
-  average_completed: number;
-  message: string;
-}
-
 // User
 export interface User {
   id: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,7 +5,7 @@ import type {
   CheckoutResponse,
   Domain,
   MITSuggestion,
-  NudgeStats,
+
   PortalResponse,
   Task,
   TaskStatus,
@@ -141,11 +141,6 @@ export async function updateDomain(
 
 export async function deleteDomain(id: string): Promise<void> {
   return request<void>(`domains/${id}`, { method: "DELETE" });
-}
-
-// Stats
-export async function getNudge(): Promise<NudgeStats> {
-  return request<NudgeStats>("stats/nudge");
 }
 
 // Account


### PR DESCRIPTION
## Summary
- Remove the numerical "nudge" banner from the Today page (task count + 30-day average)
- Remove the average comparison from the wind-down modal's DayStats component
- Keep MIT status lines in wind-down (qualitative, not metric-driven)
- Clean up dead code: `getNudge`, `NudgeStats` from API layer

## Test plan
- [ ] Open Today page — no stats banner at top, tasks start immediately after domain filters
- [ ] Open wind-down with MIT completed — shows green "You finished your most important task"
- [ ] Open wind-down with MIT incomplete — shows amber "Your most important task is still open"
- [ ] Open wind-down with no tasks remaining — shows "Today is clear" with MIT status if applicable
- [ ] Verify no console errors on Today page or wind-down

🤖 Generated with [Claude Code](https://claude.com/claude-code)