### PR TITLE
Promote domains + priority UI on task rows (#162)

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, Suspense } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import type { TriageQueue, User } from "@/lib/api-types";
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { useTheme } from "@/components/theme-provider";
 import { TriageModal } from "@/components/triage-modal";
 import { WinddownModal } from "@/components/winddown-modal";
+import { DomainNav } from "@/components/domain-nav";
 
 type NavIconName = "review" | "today" | "soon" | "later" | "someday" | "done" | "settings";
 
@@ -233,6 +234,11 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <span>Review my day</span>
             </button>
           </div>
+
+          {/* Domain nav section */}
+          <Suspense>
+            <DomainNav />
+          </Suspense>
 
           {/* Bottom section — upgrade CTA + theme toggle + settings */}
           <div className="mt-auto mx-3 pt-3 pb-4 border-t border-border/50 flex flex-col gap-0.5">

--- a/frontend/src/app/(app)/today/page.tsx
+++ b/frontend/src/app/(app)/today/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useRef, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   DndContext,
   closestCenter,
@@ -24,15 +25,15 @@ import { SortableTaskItem } from "@/components/sortable-task-item";
 import { TaskInput } from "@/components/task-input";
 import type { TaskInputHandle } from "@/components/task-input";
 import { useGlobalShortcut } from "@/hooks/useGlobalShortcut";
-import { cn } from "@/lib/utils";
 
 const BUCKET: BucketType = "today";
 
-export default function TodayPage() {
+function TodayContent() {
+  const searchParams = useSearchParams();
+  const domainFilter = searchParams.get("domain_id");
   const taskInputRef = useRef<TaskInputHandle>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [domains, setDomains] = useState<Domain[]>([]);
-  const [domainFilter, setDomainFilter] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useGlobalShortcut("n", useCallback(() => {
@@ -207,41 +208,6 @@ export default function TodayPage() {
 
   return (
     <div className="flex flex-col min-h-screen max-w-lg mx-auto px-4 py-6 gap-4">
-      {/* Domain filters */}
-      {domains.length > 0 && (
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setDomainFilter(null)}
-            className={cn(
-              "text-xs px-2.5 py-1 rounded-full border transition-colors",
-              domainFilter === null
-                ? "border-text-secondary text-text-primary"
-                : "border-border text-text-muted hover:border-text-muted",
-            )}
-          >
-            All
-          </button>
-          {domains.map((d) => (
-            <button
-              key={d.id}
-              onClick={() => setDomainFilter(domainFilter === d.id ? null : d.id)}
-              className={cn(
-                "flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border transition-colors",
-                domainFilter === d.id
-                  ? "border-text-secondary text-text-primary"
-                  : "border-border text-text-muted hover:border-text-muted",
-              )}
-            >
-              <span
-                className="h-2 w-2 rounded-full"
-                style={{ backgroundColor: d.color }}
-              />
-              {d.name}
-            </button>
-          ))}
-        </div>
-      )}
-
       {/* Task input */}
       <TaskInput ref={taskInputRef} bucket={BUCKET} domains={domains} onCreated={refresh} />
 
@@ -307,5 +273,13 @@ export default function TodayPage() {
 
       </div>
     </div>
+  );
+}
+
+export default function TodayPage() {
+  return (
+    <Suspense>
+      <TodayContent />
+    </Suspense>
   );
 }

--- a/frontend/src/components/domain-nav.tsx
+++ b/frontend/src/components/domain-nav.tsx
@@ -14,27 +14,30 @@ export function DomainNav() {
 
   const [domains, setDomains] = useState<Domain[]>([]);
   const [pendingTasks, setPendingTasks] = useState<Task[]>([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     Promise.all([getDomains(), getTasks({ status: "pending" })])
       .then(([d, t]) => {
         setDomains(d);
         setPendingTasks(t);
+        setLoaded(true);
       })
       .catch((err) => {
         console.error("DomainNav: failed to load", err);
+        setLoaded(true);
       });
   }, [pathname]);
 
-  if (domains.length === 0) return null;
+  if (!loaded || domains.length === 0) return null;
 
   function countForDomain(domainId: string): number {
     return pendingTasks.filter((t) => t.domain?.id === domainId).length;
   }
 
-  function handleClick(domainId: string) {
+  function handleClick(domainId: string | null) {
     const params = new URLSearchParams(searchParams.toString());
-    if (activeDomainId === domainId) {
+    if (domainId === null || activeDomainId === domainId) {
       params.delete("domain_id");
     } else {
       params.set("domain_id", domainId);
@@ -49,6 +52,20 @@ export function DomainNav() {
         Domains
       </p>
       <div className="flex flex-col gap-0.5">
+        {/* All — clears filter */}
+        <button
+          onClick={() => handleClick(null)}
+          className={cn(
+            "flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] transition-colors duration-150 w-full",
+            !activeDomainId
+              ? "bg-bg-hover text-text-primary font-medium"
+              : "text-text-muted hover:text-text-secondary hover:bg-bg-hover/50",
+          )}
+        >
+          <span className="h-2.5 w-2.5 rounded-full shrink-0 bg-text-muted/30" />
+          <span className="flex-1 text-left">All</span>
+        </button>
+
         {domains.map((d) => {
           const isActive = activeDomainId === d.id;
           const count = countForDomain(d.id);

--- a/frontend/src/components/domain-nav.tsx
+++ b/frontend/src/components/domain-nav.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import type { Domain, Task } from "@/lib/api-types";
+import { getDomains, getTasks } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+export function DomainNav() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const activeDomainId = searchParams.get("domain_id");
+
+  const [domains, setDomains] = useState<Domain[]>([]);
+  const [pendingTasks, setPendingTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    Promise.all([getDomains(), getTasks({ status: "pending" })])
+      .then(([d, t]) => {
+        setDomains(d);
+        setPendingTasks(t);
+      })
+      .catch((err) => {
+        console.error("DomainNav: failed to load", err);
+      });
+  }, [pathname]);
+
+  if (domains.length === 0) return null;
+
+  function countForDomain(domainId: string): number {
+    return pendingTasks.filter((t) => t.domain?.id === domainId).length;
+  }
+
+  function handleClick(domainId: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (activeDomainId === domainId) {
+      params.delete("domain_id");
+    } else {
+      params.set("domain_id", domainId);
+    }
+    const qs = params.toString();
+    router.push(`${pathname}${qs ? `?${qs}` : ""}`);
+  }
+
+  return (
+    <div className="mt-4 px-3">
+      <p className="text-[10px] font-medium uppercase tracking-widest text-text-muted px-3 mb-1">
+        Domains
+      </p>
+      <div className="flex flex-col gap-0.5">
+        {domains.map((d) => {
+          const isActive = activeDomainId === d.id;
+          const count = countForDomain(d.id);
+          return (
+            <button
+              key={d.id}
+              onClick={() => handleClick(d.id)}
+              className={cn(
+                "flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] transition-colors duration-150 w-full",
+                isActive
+                  ? "bg-bg-hover text-text-primary font-medium"
+                  : "text-text-muted hover:text-text-secondary hover:bg-bg-hover/50",
+              )}
+            >
+              <span
+                className="h-2.5 w-2.5 rounded-full shrink-0"
+                style={{ backgroundColor: d.color }}
+              />
+              <span className="flex-1 text-left truncate">{d.name}</span>
+              {count > 0 && (
+                <span className="text-[11px] text-text-muted tabular-nums">{count}</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/task-item.tsx
+++ b/frontend/src/components/task-item.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { StickyNote } from "lucide-react";
 import type { Task, Domain, SubTask } from "@/lib/api-types";
-import { completeTask, createTask, deleteTask, updateTask } from "@/lib/api";
+import { completeTask, createTask, deleteTask, updateTask, setPriority } from "@/lib/api";
 import { formatAge, ageColor, cn } from "@/lib/utils";
 import { DomainPicker } from "@/components/domain-picker";
 
@@ -143,11 +143,15 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
   const [noteSaving, setNoteSaving] = useState(false);
   const [noteError, setNoteError] = useState<string | null>(null);
   const noteTextareaRef = useRef<HTMLTextAreaElement>(null);
+  // Priority state — optimistic local copies
+  const [important, setImportant] = useState(task.important);
+  const [urgent, setUrgent] = useState(task.urgent);
   const isComplete = task.status === "complete";
   const isSubtask = !!task.parent_id;
   const hasChildren = task.children.length > 0;
   const hasNote = !!task.notes;
   const completedChildren = task.children.filter((c) => c.status === "complete").length;
+  const isQ1 = important && urgent;
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -258,6 +262,28 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
     }
   }
 
+  async function handleToggleImportant() {
+    const prev = important;
+    setImportant(!prev);
+    try {
+      await setPriority(task.id, { important: !prev });
+    } catch (err) {
+      console.error("Failed to set important:", err);
+      setImportant(prev);
+    }
+  }
+
+  async function handleToggleUrgent() {
+    const prev = urgent;
+    setUrgent(!prev);
+    try {
+      await setPriority(task.id, { urgent: !prev });
+    } catch (err) {
+      console.error("Failed to set urgent:", err);
+      setUrgent(prev);
+    }
+  }
+
   function startNoteEdit() {
     setNoteDraft(task.notes ?? "");
     setNoteEditing(true);
@@ -313,7 +339,10 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
       <div className={cn(
         "flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-bg-hover transition-colors",
         isMIT && "bg-accent-blue/8 border border-accent-blue/20",
-      )}>
+        isQ1 && !isComplete && "border-l-2 border-red-500",
+      )}
+        style={isQ1 && !isComplete ? { backgroundColor: "rgba(239,68,68,0.08)" } : undefined}
+      >
         {/* Complete checkbox */}
         <button
           onClick={handleComplete}
@@ -457,6 +486,38 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
           <span className="text-xs text-text-muted shrink-0">
             {completedChildren}/{task.children.length}
           </span>
+        )}
+
+        {/* Priority pills — shown on hover, hidden on completed tasks */}
+        {!isComplete && (
+          <>
+            <button
+              onClick={handleToggleImportant}
+              title={important ? "Remove important" : "Mark as important"}
+              className={cn(
+                "shrink-0 text-[10px] px-1.5 py-0.5 rounded border transition-all duration-150",
+                important
+                  ? "opacity-100 border-red-500/35 bg-red-500/8 text-red-300"
+                  : "opacity-0 group-hover:opacity-100 border-neutral-800 text-neutral-500 hover:text-neutral-400",
+              )}
+              style={important ? { color: "#fca5a5", borderColor: "rgba(239,68,68,0.35)", backgroundColor: "rgba(239,68,68,0.08)" } : undefined}
+            >
+              !
+            </button>
+            <button
+              onClick={handleToggleUrgent}
+              title={urgent ? "Remove urgent" : "Mark as urgent"}
+              className={cn(
+                "shrink-0 text-[10px] px-1.5 py-0.5 rounded border transition-all duration-150",
+                urgent
+                  ? "opacity-100 border-amber-500/35 bg-amber-500/8 text-amber-300"
+                  : "opacity-0 group-hover:opacity-100 border-neutral-800 text-neutral-500 hover:text-neutral-400",
+              )}
+              style={urgent ? { color: "#fcd34d", borderColor: "rgba(245,158,11,0.35)", backgroundColor: "rgba(245,158,11,0.08)" } : undefined}
+            >
+              ⚡
+            </button>
+          </>
         )}
 
         {/* Age badge */}

--- a/frontend/src/components/task-item.tsx
+++ b/frontend/src/components/task-item.tsx
@@ -143,9 +143,16 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
   const [noteSaving, setNoteSaving] = useState(false);
   const [noteError, setNoteError] = useState<string | null>(null);
   const noteTextareaRef = useRef<HTMLTextAreaElement>(null);
-  // Priority state — optimistic local copies
+  // Priority state — optimistic local copies, kept in sync with incoming props
   const [important, setImportant] = useState(task.important);
   const [urgent, setUrgent] = useState(task.urgent);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+  useEffect(() => { setImportant(task.important); }, [task.important]);
+  useEffect(() => { setUrgent(task.urgent); }, [task.urgent]);
   const isComplete = task.status === "complete";
   const isSubtask = !!task.parent_id;
   const hasChildren = task.children.length > 0;
@@ -267,9 +274,10 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
     setImportant(!prev);
     try {
       await setPriority(task.id, { important: !prev });
+      onMutate();
     } catch (err) {
       console.error("Failed to set important:", err);
-      setImportant(prev);
+      if (mountedRef.current) setImportant(prev);
     }
   }
 
@@ -278,9 +286,10 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
     setUrgent(!prev);
     try {
       await setPriority(task.id, { urgent: !prev });
+      onMutate();
     } catch (err) {
       console.error("Failed to set urgent:", err);
-      setUrgent(prev);
+      if (mountedRef.current) setUrgent(prev);
     }
   }
 
@@ -339,10 +348,8 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
       <div className={cn(
         "flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-bg-hover transition-colors",
         isMIT && "bg-accent-blue/8 border border-accent-blue/20",
-        isQ1 && !isComplete && "border-l-2 border-red-500",
-      )}
-        style={isQ1 && !isComplete ? { backgroundColor: "rgba(239,68,68,0.08)" } : undefined}
-      >
+        isQ1 && !isComplete && "border-l-2 border-red-500 bg-red-500/[0.08]",
+      )}>
         {/* Complete checkbox */}
         <button
           onClick={handleComplete}
@@ -493,19 +500,20 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
           <>
             <button
               onClick={handleToggleImportant}
+              aria-label={important ? "Remove important" : "Mark as important"}
               title={important ? "Remove important" : "Mark as important"}
               className={cn(
-                "shrink-0 text-[10px] px-1.5 py-0.5 rounded border transition-all duration-150",
+                "shrink-0 font-mono text-[10px] px-1.5 py-0.5 rounded border transition-all duration-150",
                 important
                   ? "opacity-100 border-red-500/35 bg-red-500/8 text-red-300"
                   : "opacity-0 group-hover:opacity-100 border-neutral-800 text-neutral-500 hover:text-neutral-400",
               )}
-              style={important ? { color: "#fca5a5", borderColor: "rgba(239,68,68,0.35)", backgroundColor: "rgba(239,68,68,0.08)" } : undefined}
             >
               !
             </button>
             <button
               onClick={handleToggleUrgent}
+              aria-label={urgent ? "Remove urgent" : "Mark as urgent"}
               title={urgent ? "Remove urgent" : "Mark as urgent"}
               className={cn(
                 "shrink-0 text-[10px] px-1.5 py-0.5 rounded border transition-all duration-150",
@@ -513,7 +521,6 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT }: TaskItemP
                   ? "opacity-100 border-amber-500/35 bg-amber-500/8 text-amber-300"
                   : "opacity-0 group-hover:opacity-100 border-neutral-800 text-neutral-500 hover:text-neutral-400",
               )}
-              style={urgent ? { color: "#fcd34d", borderColor: "rgba(245,158,11,0.35)", backgroundColor: "rgba(245,158,11,0.08)" } : undefined}
             >
               ⚡
             </button>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -43,6 +43,8 @@ export interface Task {
   completed_at: string | null;
   age_days: number;
   is_mit: boolean;
+  important: boolean;
+  urgent: boolean;
 }
 
 // MIT suggestion from the backend

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -96,6 +96,13 @@ export async function reorderTasks(taskIds: string[]): Promise<{ updated: number
   });
 }
 
+export async function setPriority(
+  id: string,
+  body: { important?: boolean; urgent?: boolean },
+): Promise<Task> {
+  return request<Task>(`tasks/${id}/priority`, { method: "POST", body: JSON.stringify(body) });
+}
+
 // Triage
 export async function getTriageQueue(): Promise<TriageQueue> {
   return request<TriageQueue>("triage");


### PR DESCRIPTION
## Summary

- Adds `important` and `urgent` boolean fields to the frontend `Task` type and API layer
- Moves the domain filter from an inline pill row on the Today page into a persistent sidebar section (`DomainNav`) using URL param `?domain_id=<id>` for cross-page state
- Adds `!` (important) and `⚡` (urgent) priority pills to every `TaskItem` — hidden by default, visible on hover, with active red/amber styling from the prototype spec
- Q1 tasks (both important + urgent) get a 2px red left border and `rgba(239,68,68,0.08)` tinted background on the row
- All priority toggles use optimistic updates with rollback on failure

## Changes

- `api-types.ts` — add `important: boolean` and `urgent: boolean` to `Task` interface
- `api.ts` — add `setPriority(id, {important?, urgent?})` calling `POST /tasks/{id}/priority`
- `components/domain-nav.tsx` — new client component: fetches domains + pending tasks, renders sidebar nav with colored dots + task counts, filters via `?domain_id` URL param
- `(app)/layout.tsx` — import and render `DomainNav` below main nav items (desktop sidebar only), wrapped in Suspense
- `(app)/today/page.tsx` — remove domain pill row, read `domainFilter` from `useSearchParams("domain_id")`, wrap in Suspense for production compatibility
- `components/task-item.tsx` — add optimistic priority state, `handleToggleImportant`/`handleToggleUrgent` with try/catch rollback, priority pills (opacity-0 → visible on group-hover), Q1 row border + bg

## Test plan

- [ ] Confirm sidebar shows domain list with task counts after creating domains
- [ ] Click a domain in the sidebar — Today page filters to that domain, URL shows `?domain_id=<id>`
- [ ] Click again to clear the filter
- [ ] Hover a task row — `!` and `⚡` pills appear
- [ ] Click `!` — pill turns red, task shows important active styling
- [ ] Click `⚡` — pill turns amber, task shows urgent active styling
- [ ] Both active → row gets 2px red left border + red-tinted background (Q1 styling)
- [ ] Completed tasks show no priority pills
- [ ] Build passes: `npm run build` exits 0 with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)