### PR TITLE
Mobile: make wind-down ritual flow mobile-friendly

### DIFF
--- a/frontend/src/components/winddown-modal.tsx
+++ b/frontend/src/components/winddown-modal.tsx
@@ -82,7 +82,7 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
           <p className="text-base text-text-secondary">
             Couldn&apos;t load your tasks.
           </p>
-          <button onClick={onComplete} className="text-sm text-accent-blue hover:underline">
+          <button onClick={onComplete} className="text-sm text-accent-blue hover:underline min-h-[44px] px-4">
             Close
           </button>
         </div>
@@ -106,7 +106,7 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
               Nothing left to close out. Nice work.
             </p>
           </div>
-          <button onClick={onComplete} className="text-sm text-accent-blue hover:underline">
+          <button onClick={onComplete} className="text-sm text-accent-blue hover:underline min-h-[44px] px-4">
             Close
           </button>
         </div>
@@ -191,7 +191,7 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
         </div>
         <button
           onClick={onComplete}
-          className="text-sm text-accent-blue hover:underline"
+          className="text-sm text-accent-blue hover:underline min-h-[44px] px-4"
         >
           Close
         </button>


### PR DESCRIPTION
## Summary
- `winddown-modal.tsx`: adds `min-h-[44px] px-4` to all three Close buttons (error state, empty state, summary) for thumb-reachable tap targets
- `TriageCard` action buttons and `RitualOverlay` safe area already handled by #144 (merged)

Closes #145

## Test plan
- [ ] Open wind-down on a mobile viewport (Chrome DevTools iPhone SE)
- [ ] Verify intro screen fits without scroll issues
- [ ] Walk through cards → summary, confirm Close button is easy to tap
- [ ] Check empty state ("Today is clear") Close button tap target
- [ ] Verify action buttons (Today/Soon/Later/Someday) meet 44px tap target (from TriageCard fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)