### PR TITLE
Mobile: make settings and onboarding pages mobile-friendly

### DIFF
--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -169,40 +169,42 @@ function SettingsContent() {
             className="flex items-center gap-3 rounded-lg bg-bg-card border border-border px-3 py-2"
           >
             {editingId === d.id ? (
-              <>
-                <div className="flex gap-1">
+              <div className="flex flex-col gap-2 w-full">
+                <div className="flex flex-wrap gap-1.5">
                   {PRESET_COLORS.map((c) => (
                     <button
                       key={c}
                       onClick={() => setEditColor(c)}
                       className={cn(
-                        "h-5 w-5 rounded-full transition-transform",
+                        "h-7 w-7 rounded-full transition-transform",
                         editColor === c && "ring-2 ring-text-primary ring-offset-1 ring-offset-bg-card scale-110",
                       )}
                       style={{ backgroundColor: c }}
                     />
                   ))}
                 </div>
-                <input
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  className="flex-1 bg-bg-input border border-border rounded px-2 py-1 text-sm text-text-primary outline-none"
-                  maxLength={30}
-                  autoFocus
-                />
-                <button
-                  onClick={() => handleSaveEdit(d.id)}
-                  className="text-xs text-accent-green hover:underline"
-                >
-                  Save
-                </button>
-                <button
-                  onClick={() => setEditingId(null)}
-                  className="text-xs text-text-muted hover:underline"
-                >
-                  Cancel
-                </button>
-              </>
+                <div className="flex items-center gap-2">
+                  <input
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    className="flex-1 bg-bg-input border border-border rounded px-2 py-1.5 text-sm text-text-primary outline-none"
+                    maxLength={30}
+                    autoFocus
+                  />
+                  <button
+                    onClick={() => handleSaveEdit(d.id)}
+                    className="text-sm text-accent-green hover:underline min-h-[44px] px-2"
+                  >
+                    Save
+                  </button>
+                  <button
+                    onClick={() => setEditingId(null)}
+                    className="text-sm text-text-muted hover:underline min-h-[44px] px-2"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
             ) : (
               <>
                 <span
@@ -229,35 +231,37 @@ function SettingsContent() {
 
         {/* Add domain */}
         {domains.length < domainLimit ? (
-          <div className="flex items-center gap-3 rounded-lg bg-bg-card border border-border px-3 py-2">
-            <div className="flex gap-1">
+          <div className="flex flex-col gap-2 rounded-lg bg-bg-card border border-border px-3 py-2.5">
+            <div className="flex flex-wrap gap-1.5">
               {PRESET_COLORS.map((c) => (
                 <button
                   key={c}
                   onClick={() => setNewColor(c)}
                   className={cn(
-                    "h-5 w-5 rounded-full transition-transform",
+                    "h-7 w-7 rounded-full transition-transform",
                     newColor === c && "ring-2 ring-text-primary ring-offset-1 ring-offset-bg-card scale-110",
                   )}
                   style={{ backgroundColor: c }}
                 />
               ))}
             </div>
-            <input
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              placeholder="New domain..."
-              className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none"
-              maxLength={30}
-              onKeyDown={(e) => e.key === "Enter" && handleAddDomain()}
-            />
-            <button
-              onClick={handleAddDomain}
-              disabled={!newName.trim()}
-              className="text-xs text-accent-blue hover:underline disabled:opacity-30"
-            >
-              Add
-            </button>
+            <div className="flex items-center gap-2">
+              <input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="New domain..."
+                className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none"
+                maxLength={30}
+                onKeyDown={(e) => e.key === "Enter" && handleAddDomain()}
+              />
+              <button
+                onClick={handleAddDomain}
+                disabled={!newName.trim()}
+                className="text-sm text-accent-blue hover:underline disabled:opacity-30 min-h-[44px] px-2"
+              >
+                Add
+              </button>
+            </div>
           </div>
         ) : user?.is_pro ? (
           <p className="text-xs text-text-muted">Maximum {PRO_DOMAIN_LIMIT} domains reached.</p>

--- a/frontend/src/components/onboarding-domain-picker.tsx
+++ b/frontend/src/components/onboarding-domain-picker.tsx
@@ -61,34 +61,38 @@ export function OnboardingDomainPicker({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className={cn(
-          "h-5 w-5 rounded-full border flex items-center justify-center transition-colors",
-          currentDomain
-            ? "border-border hover:border-text-secondary"
-            : "border-dashed border-text-muted hover:border-text-secondary",
-        )}
+        className="h-11 w-11 flex items-center justify-center"
         aria-label={currentDomain ? `Domain: ${currentDomain.name}. Click to change` : "Set domain"}
         aria-expanded={isOpen}
         title={currentDomain ? `${currentDomain.name} (click to change)` : "Set domain"}
       >
-        {currentDomain ? (
-          <span
-            className="h-2.5 w-2.5 rounded-full"
-            style={{ backgroundColor: currentDomain.color }}
-          />
-        ) : (
-          <span className="text-text-muted text-[10px]">+</span>
-        )}
+        <span
+          className={cn(
+            "h-5 w-5 rounded-full border flex items-center justify-center transition-colors",
+            currentDomain
+              ? "border-border hover:border-text-secondary"
+              : "border-dashed border-text-muted hover:border-text-secondary",
+          )}
+        >
+          {currentDomain ? (
+            <span
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: currentDomain.color }}
+            />
+          ) : (
+            <span className="text-text-muted text-[10px]">+</span>
+          )}
+        </span>
       </button>
       {isOpen && (
-        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 z-10 flex items-center gap-1 bg-bg-card border border-border rounded-lg px-1.5 py-1.5 shadow-lg">
+        <div className="absolute top-full left-0 mt-1 z-10 flex flex-col bg-bg-card border border-border rounded-lg py-1 shadow-lg min-w-[120px]">
           {domains.map((d) => (
             <button
               key={d.id}
               type="button"
               onClick={() => selectDomain(d.id)}
               className={cn(
-                "flex items-center gap-1 px-1.5 py-1 rounded-md transition-colors",
+                "flex items-center gap-2 px-3 min-h-[44px] rounded-md transition-colors",
                 currentDomainId === d.id
                   ? "bg-bg-hover"
                   : "hover:bg-bg-hover",
@@ -100,14 +104,14 @@ export function OnboardingDomainPicker({
                 className="h-2.5 w-2.5 rounded-full shrink-0"
                 style={{ backgroundColor: d.color }}
               />
-              <span className="text-[10px] text-text-secondary whitespace-nowrap">{d.name}</span>
+              <span className="text-sm text-text-secondary whitespace-nowrap">{d.name}</span>
             </button>
           ))}
           <button
             type="button"
             onClick={() => selectDomain(undefined)}
             className={cn(
-              "flex items-center gap-1 px-1.5 py-1 rounded-md transition-colors",
+              "flex items-center gap-2 px-3 min-h-[44px] rounded-md transition-colors",
               !currentDomainId
                 ? "bg-bg-hover"
                 : "hover:bg-bg-hover",
@@ -116,7 +120,7 @@ export function OnboardingDomainPicker({
             title="None"
           >
             <span className="h-2.5 w-2.5 rounded-full border border-text-muted shrink-0" />
-            <span className="text-[10px] text-text-muted whitespace-nowrap">None</span>
+            <span className="text-sm text-text-muted whitespace-nowrap">None</span>
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
**settings/page.tsx:**
- Domain edit and add rows restructured: color picker stacks on its own row (`flex-col`) so 10 dots don't overflow at 320px width
- Color dot size: `h-5 w-5` → `h-7 w-7` for better visual touch affordance
- Save/Cancel/Add buttons: `text-xs` → `text-sm` + `min-h-[44px]` for 44px tap targets

**onboarding-domain-picker.tsx:**
- Trigger button wrapped in `h-11 w-11` tap area (inner visual dot stays `h-5 w-5`)
- Dropdown changed from horizontal pill row to vertical list anchored `left-0`, with `min-h-[44px]` per item and `text-sm` labels

No backend changes. No structural changes to onboarding steps (domain checkboxes already `py-3 w-full`, upgrade modal already `max-w-sm mx-4`).

Closes #146

## Test plan
- [ ] Settings page: open on 375px viewport, verify color picker wraps to new row
- [ ] Settings: tap Edit on a domain, verify color dots and Save/Cancel are easily tappable
- [ ] Settings: add a new domain, verify color picker + input + Add button on two rows, no horizontal scroll
- [ ] Settings: trigger upgrade modal, verify it fits and buttons stack cleanly
- [ ] Onboarding step 2: domain toggle checkboxes are comfortably tappable
- [ ] Onboarding step 3: tap the ⊕ domain picker, verify dropdown is a vertical list with large tap targets
- [ ] No horizontal scroll at 320px width on either page

🤖 Generated with [Claude Code](https://claude.com/claude-code)