### PR TITLE
Fix: remove triageChecked from content gate to eliminate flash (#171)

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -49,7 +49,6 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const [onboardingChecked, setOnboardingChecked] = useState(false);
-  const [triageChecked, setTriageChecked] = useState(false);
   const [showTriageModal, setShowTriageModal] = useState(false);
   const [showWinddownModal, setShowWinddownModal] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -136,7 +135,6 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     if (skipGates || !onboardingChecked) return;
 
     if (isTriageDoneToday()) {
-      setTriageChecked(true);
       return;
     }
 
@@ -149,11 +147,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           // Backend says triage is complete — remember for this session
           markTriageDone();
         }
-        setTriageChecked(true);
       })
       .catch((err) => {
         console.error("Triage check failed:", err);
-        setTriageChecked(true);
       });
   }
 
@@ -172,7 +168,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     return () => document.removeEventListener("visibilitychange", handleVisibility);
   }, [skipGates, onboardingChecked]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const showContent = skipGates || (onboardingChecked && triageChecked);
+  const showContent = skipGates || onboardingChecked;
   const hideNav = pathname === "/onboarding";
   const modalOpen = showTriageModal || showWinddownModal;
 


### PR DESCRIPTION
## Summary

- Removes `triageChecked` state variable from `layout.tsx` entirely
- Changes `showContent` from `skipGates || (onboardingChecked && triageChecked)` to `skipGates || onboardingChecked`
- Removes `setTriageChecked(true)` calls from `checkTriage()` (the function and its two `useEffect` triggers remain intact)

## Why

Every navigation triggered a blank "Loading…" flash because `showContent` was gated on `triageChecked`, which required an async `getTriageQueue()` call to resolve. The triage check is a background concern — it should show a modal when needed, not delay page rendering.

## What stays the same

- Onboarding gate still redirects to `/onboarding` when needed
- `checkTriage()` still fires on pathname change and tab visibility
- `showTriageModal` still pops the triage modal when the queue has items
- `markTriageDone()` / `isTriageDoneToday()` sessionStorage caching unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)