### PR TITLE
Add triage_reminder_enabled and triage_reminder_hour to User model (#172)

### DIFF
--- a/backend/alembic/versions/20260429_add_triage_reminder_fields.py
+++ b/backend/alembic/versions/20260429_add_triage_reminder_fields.py
@@ -1,0 +1,26 @@
+"""Add triage_reminder_enabled and triage_reminder_hour to users
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-29 00:00:00.000000
+"""
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'c3d4e5f6a7b8'
+down_revision: Union[str, Sequence[str], None] = 'b2c3d4e5f6a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('triage_reminder_enabled', sa.Boolean(), nullable=False, server_default=sa.text('true')))
+    op.add_column('users', sa.Column('triage_reminder_hour', sa.Integer(), nullable=False, server_default=sa.text('7')))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'triage_reminder_hour')
+    op.drop_column('users', 'triage_reminder_enabled')

--- a/backend/app/api/account.py
+++ b/backend/app/api/account.py
@@ -42,6 +42,8 @@ def _to_response(user: User) -> UserResponse:
         subscription_status=user.subscription_status,
         is_pro=user.subscription_status in ("active", "past_due"),
         default_layout=user.default_layout,
+        triage_reminder_enabled=user.triage_reminder_enabled,
+        triage_reminder_hour=user.triage_reminder_hour,
     )
 
 
@@ -179,6 +181,12 @@ def update_me(
 
     if body.default_layout is not None:
         user.default_layout = body.default_layout
+
+    if body.triage_reminder_enabled is not None:
+        user.triage_reminder_enabled = body.triage_reminder_enabled
+
+    if body.triage_reminder_hour is not None:
+        user.triage_reminder_hour = body.triage_reminder_hour
 
     db.add(user)
     db.flush()

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -26,6 +26,8 @@ class User(SQLModel, table=True):
         default=LayoutType.list,
         sa_column=Column(String, nullable=False, server_default="list"),
     )
+    triage_reminder_enabled: bool = Field(default=True)
+    triage_reminder_hour: int = Field(default=7)  # 0–23, user's local hour
 
     # Relationships — lazy="raise" prevents N+1 queries
     tasks: list["Task"] = Relationship(  # noqa: F821

--- a/backend/app/schemas/user_schemas.py
+++ b/backend/app/schemas/user_schemas.py
@@ -29,6 +29,8 @@ class UserResponse(BaseModel):
     subscription_status: str = "free"
     is_pro: bool = False
     default_layout: LayoutType = LayoutType.list
+    triage_reminder_enabled: bool
+    triage_reminder_hour: int
 
 
 class OAuthUser(BaseModel):
@@ -43,6 +45,15 @@ class UserVerify(BaseModel):
 class UserUpdate(BaseModel):
     has_completed_onboarding: bool | None = None
     default_layout: LayoutType | None = None
+    triage_reminder_enabled: bool | None = None
+    triage_reminder_hour: int | None = None
+
+    @field_validator("triage_reminder_hour")
+    @classmethod
+    def validate_reminder_hour(cls, v: int | None) -> int | None:
+        if v is not None and not (0 <= v <= 23):
+            raise ValueError("triage_reminder_hour must be between 0 and 23")
+        return v
 
 
 class ForgotPasswordRequest(BaseModel):

--- a/backend/tests/test_account.py
+++ b/backend/tests/test_account.py
@@ -35,6 +35,29 @@ class TestAccount:
         assert r.status_code == 200
         assert r.json()["has_completed_onboarding"] is True
 
+    def test_get_me_includes_triage_reminder_fields(self, client, test_user):
+        r = client.get("/me")
+        assert r.status_code == 200
+        data = r.json()
+        assert "triage_reminder_enabled" in data
+        assert "triage_reminder_hour" in data
+        assert data["triage_reminder_enabled"] is True
+        assert data["triage_reminder_hour"] == 7
+
+    def test_update_me_triage_reminder_enabled(self, client, test_user):
+        r = client.patch("/me", json={"triage_reminder_enabled": False})
+        assert r.status_code == 200
+        assert r.json()["triage_reminder_enabled"] is False
+
+    def test_update_me_triage_reminder_hour_valid(self, client, test_user):
+        r = client.patch("/me", json={"triage_reminder_hour": 9})
+        assert r.status_code == 200
+        assert r.json()["triage_reminder_hour"] == 9
+
+    def test_update_me_triage_reminder_hour_invalid(self, client, test_user):
+        r = client.patch("/me", json={"triage_reminder_hour": 25})
+        assert r.status_code == 422
+
     def test_verify_user_success(self, client, db):
         """Verify correct email/password returns user."""
         client.post("/users", json={"email": "verify@tend.app", "password": "correct123"})


### PR DESCRIPTION
## Summary

- Adds `triage_reminder_enabled: bool` (default `True`) and `triage_reminder_hour: int` (default `7`, range 0–23) to the `User` model
- Wires both fields through `UserResponse`, `UserUpdate` (with validator rejecting hours outside 0–23), the `PATCH /me` endpoint, and a date-prefixed Alembic migration
- 4 new tests covering persistence, validation (422 on hour=25), and GET response inclusion

## Test plan

- [x] `PATCH /users/me` with `triage_reminder_enabled: false` persists and returns `false`
- [x] `PATCH /users/me` with `triage_reminder_hour: 25` returns 422
- [x] `PATCH /users/me` with `triage_reminder_hour: 9` returns 200 with updated value
- [x] `GET /users/me` response includes both fields with correct defaults
- [x] All 174 existing tests pass
- [x] Ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)