### PR TITLE
Triage reminder skip/disable, domain picker overflow, priority on task creation

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useRef, Suspense } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import type { User } from "@/lib/api-types";
-import { getTriageQueue, getMe, createCheckout, getAppState } from "@/lib/api";
+import { getTriageQueue, getMe, updateMe, createCheckout, getAppState } from "@/lib/api";
 import type { BucketCounts } from "@/lib/api-types";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/components/theme-provider";
@@ -122,6 +122,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   // Once triage is done (completed or skipped) for the day, we store it in
   // sessionStorage so no re-check can re-trigger the modal.
   const TRIAGE_DONE_KEY = "triage_done_today";
+  const TRIAGE_SKIP_KEY = "triage_skipped_date";
 
   function isTriageDoneToday() {
     return sessionStorage.getItem(TRIAGE_DONE_KEY) === new Date().toDateString();
@@ -131,8 +132,21 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     sessionStorage.setItem(TRIAGE_DONE_KEY, new Date().toDateString());
   }
 
+  function isTriageSkippedToday() {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(TRIAGE_SKIP_KEY) === new Date().toDateString();
+  }
+
+  function markTriageSkippedToday() {
+    localStorage.setItem(TRIAGE_SKIP_KEY, new Date().toDateString());
+  }
+
   function checkTriage() {
     if (skipGates || !onboardingChecked) return;
+    if (user && !user.triage_reminder_enabled) {
+      setTriagePending(false);
+      return;
+    }
 
     if (isTriageDoneToday()) {
       setTriagePending(false);
@@ -143,7 +157,10 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       .then((q) => {
         if (!q.triage_complete && q.tasks.length > 0) {
           setTriagePending(true);
-          setShowTriageBanner(true);
+          // Banner is dismissed via hard skip, but the rail link still shows.
+          if (!isTriageSkippedToday()) {
+            setShowTriageBanner(true);
+          }
         } else {
           markTriageDone();
           setTriagePending(false);
@@ -156,7 +173,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     checkTriage();
-  }, [pathname, skipGates, onboardingChecked]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pathname, skipGates, onboardingChecked, user?.triage_reminder_enabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Re-check triage when a stale tab becomes visible again
   useEffect(() => {
@@ -380,7 +397,19 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       {showTriageBanner && !skipGates && (
         <TriageReminderBanner
           onStart={() => { setShowTriageBanner(false); router.push("/triage"); }}
-          onDismiss={() => setShowTriageBanner(false)}
+          onSkipToday={() => {
+            markTriageSkippedToday();
+            setShowTriageBanner(false);
+          }}
+          onTurnOff={async () => {
+            setShowTriageBanner(false);
+            try {
+              const updated = await updateMe({ triage_reminder_enabled: false });
+              setUser(updated);
+            } catch (err) {
+              console.error("Failed to disable reminders:", err);
+            }
+          }}
           isFirstTime={user ? !user.has_triaged_before : false}
         />
       )}

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -14,6 +14,7 @@ import {
   sendFeedback,
   createCheckout,
   createPortalSession,
+  updateMe,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/components/theme-provider";
@@ -342,6 +343,34 @@ function SettingsContent() {
       )}
 
       {/* Appearance */}
+      {/* Triage reminders */}
+      <section className="space-y-3 pt-4 border-t border-border">
+        <h2 className="text-sm font-medium text-text-secondary">Triage reminders</h2>
+        <p className="text-xs text-text-muted leading-relaxed">
+          A daily nudge to triage your tasks. You can still triage anytime from the sidebar.
+        </p>
+        <button
+          onClick={async () => {
+            if (!user) return;
+            const next = !user.triage_reminder_enabled;
+            try {
+              const updated = await updateMe({ triage_reminder_enabled: next });
+              setUser(updated);
+            } catch (err) {
+              console.error("Failed to update reminder setting:", err);
+            }
+          }}
+          className={cn(
+            "flex items-center gap-3 text-sm border rounded-lg px-4 py-2 transition-colors",
+            user?.triage_reminder_enabled
+              ? "text-text-secondary border-border hover:bg-bg-hover"
+              : "text-text-muted border-border hover:bg-bg-hover",
+          )}
+        >
+          {user?.triage_reminder_enabled ? "Reminders on — turn off" : "Reminders off — turn on"}
+        </button>
+      </section>
+
       <section className="space-y-3 pt-4 border-t border-border">
         <h2 className="text-sm font-medium text-text-secondary">Appearance</h2>
         <button

--- a/frontend/src/components/domain-picker.tsx
+++ b/frontend/src/components/domain-picker.tsx
@@ -16,6 +16,7 @@ export function DomainPicker({ taskId, currentDomain, domains, onMutate }: Domai
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [openUpward, setOpenUpward] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   // Close picker when domain changes externally (plan edge case #3)
@@ -73,10 +74,20 @@ export function DomainPicker({ taskId, currentDomain, domains, onMutate }: Domai
     }
   }
 
+  function handleToggle() {
+    if (!isOpen && ref.current) {
+      // Estimate dropdown height (~36px) and flip up if there's not enough room below.
+      const rect = ref.current.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
+      setOpenUpward(spaceBelow < 80);
+    }
+    setIsOpen((v) => !v);
+  }
+
   return (
     <div className="relative shrink-0" ref={ref}>
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleToggle}
         disabled={loading}
         className={cn(
           "h-5 w-5 rounded-full border flex items-center justify-center transition-colors",
@@ -99,7 +110,12 @@ export function DomainPicker({ taskId, currentDomain, domains, onMutate }: Domai
         )}
       </button>
       {isOpen && (
-        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 z-10 flex items-center gap-1 bg-bg-card border border-border rounded-lg px-1.5 py-1.5 shadow-lg">
+        <div
+          className={cn(
+            "absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 bg-bg-card border border-border rounded-lg px-1.5 py-1.5 shadow-lg",
+            openUpward ? "bottom-full mb-1" : "top-full mt-1",
+          )}
+        >
           {domains.map((d) => (
             <button
               key={d.id}

--- a/frontend/src/components/task-input.tsx
+++ b/frontend/src/components/task-input.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
 import type { BucketType, Domain } from "@/lib/api-types";
 import { createTask } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 type Phase = "typing" | "selecting" | "submitting";
 
@@ -21,6 +22,8 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
   const [phase, setPhase] = useState<Phase>("typing");
   // Index into [undefined, ...domains] where undefined = "None"
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [important, setImportant] = useState(false);
+  const [urgent, setUrgent] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const chipContainerRef = useRef<HTMLDivElement>(null);
 
@@ -37,15 +40,23 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
   const resetToTyping = useCallback(() => {
     setText("");
     setSelectedIndex(0);
+    setImportant(false);
+    setUrgent(false);
     setPhase("typing");
     setShouldRefocus(true);
   }, []);
 
-  const submitTask = useCallback(async (taskText: string, domainIndex: number) => {
+  const submitTask = useCallback(async (taskText: string, domainIndex: number, isImportant: boolean, isUrgent: boolean) => {
     setPhase("submitting");
     const domainId = domainIndex > 0 ? domains[domainIndex - 1]?.id : undefined;
     try {
-      await createTask({ text: taskText, bucket, domain_id: domainId });
+      await createTask({
+        text: taskText,
+        bucket,
+        domain_id: domainId,
+        important: isImportant,
+        urgent: isUrgent,
+      });
       onCreated();
     } catch (err) {
       console.error("Failed to create task:", err);
@@ -61,7 +72,7 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
 
     if (!hasDomains) {
       // No domains — skip Phase 2, create immediately
-      submitTask(trimmed, 0);
+      submitTask(trimmed, 0, important, urgent);
     } else {
       setPhase("selecting");
     }
@@ -82,15 +93,26 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
         setSelectedIndex((prev) => (prev - 1 + optionCount) % optionCount);
         break;
       }
+      case "!": {
+        e.preventDefault();
+        setImportant((v) => !v);
+        break;
+      }
+      case "u":
+      case "U": {
+        e.preventDefault();
+        setUrgent((v) => !v);
+        break;
+      }
       case "Enter": {
         e.preventDefault();
-        submitTask(text.trim(), selectedIndex);
+        submitTask(text.trim(), selectedIndex, important, urgent);
         break;
       }
       case "Escape": {
         e.preventDefault();
         // Skip domain, create with no domain
-        submitTask(text.trim(), 0);
+        submitTask(text.trim(), 0, important, urgent);
         break;
       }
     }
@@ -153,7 +175,7 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
             tabIndex={-1}
             onClick={() => {
               setSelectedIndex(0);
-              submitTask(text.trim(), 0);
+              submitTask(text.trim(), 0, important, urgent);
             }}
             className={`shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs transition-all ${
               selectedIndex === 0
@@ -178,7 +200,7 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
                 tabIndex={-1}
                 onClick={() => {
                   setSelectedIndex(optIndex);
-                  submitTask(text.trim(), optIndex);
+                  submitTask(text.trim(), optIndex, important, urgent);
                 }}
                 className={`shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs transition-all ${
                   isActive
@@ -197,8 +219,47 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
             );
           })}
 
+          {/* Divider */}
+          <span className="h-4 w-px bg-border mx-1" aria-hidden />
+
+          {/* Important toggle */}
+          <button
+            type="button"
+            tabIndex={-1}
+            onClick={() => setImportant((v) => !v)}
+            aria-pressed={important}
+            aria-label={important ? "Remove important" : "Mark as important"}
+            title={important ? "Important (press !)" : "Important (press !)"}
+            className={cn(
+              "shrink-0 font-mono text-[11px] h-6 w-6 rounded border flex items-center justify-center transition-all",
+              important
+                ? "border-red-500/40 bg-red-500/10 text-red-400"
+                : "border-border text-text-muted hover:border-text-muted",
+            )}
+          >
+            !
+          </button>
+
+          {/* Urgent toggle */}
+          <button
+            type="button"
+            tabIndex={-1}
+            onClick={() => setUrgent((v) => !v)}
+            aria-pressed={urgent}
+            aria-label={urgent ? "Remove urgent" : "Mark as urgent"}
+            title={urgent ? "Urgent (press u)" : "Urgent (press u)"}
+            className={cn(
+              "shrink-0 text-[11px] h-6 w-6 rounded border flex items-center justify-center transition-all",
+              urgent
+                ? "border-amber-500/40 bg-amber-500/10 text-amber-400"
+                : "border-border text-text-muted hover:border-text-muted",
+            )}
+          >
+            ⚡
+          </button>
+
           <span className="text-xs text-text-muted ml-1">
-            ← → then Enter
+            ← → ! u then Enter
           </span>
         </div>
       </div>

--- a/frontend/src/components/triage-reminder-banner.tsx
+++ b/frontend/src/components/triage-reminder-banner.tsx
@@ -2,11 +2,12 @@
 
 interface TriageReminderBannerProps {
   onStart: () => void;
-  onDismiss: () => void;
+  onSkipToday: () => void;
+  onTurnOff: () => void;
   isFirstTime?: boolean;
 }
 
-export function TriageReminderBanner({ onStart, onDismiss, isFirstTime }: TriageReminderBannerProps) {
+export function TriageReminderBanner({ onStart, onSkipToday, onTurnOff, isFirstTime }: TriageReminderBannerProps) {
   const message = isFirstTime
     ? "Ready for your first triage? It only takes a few minutes."
     : "Time to triage — you haven't sorted today's tasks yet.";
@@ -31,12 +32,18 @@ export function TriageReminderBanner({ onStart, onDismiss, isFirstTime }: Triage
             Start triage
           </button>
           <button
-            onClick={onDismiss}
+            onClick={onSkipToday}
             className="flex-1 rounded-xl border border-border px-4 py-2.5 text-sm text-text-secondary hover:bg-bg-hover transition-colors min-h-[44px]"
           >
-            Maybe later
+            Skip today
           </button>
         </div>
+        <button
+          onClick={onTurnOff}
+          className="block w-full text-center text-xs text-text-muted hover:text-text-secondary transition-colors py-1"
+        >
+          Turn off reminders
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -104,6 +104,8 @@ export interface User {
   subscription_status: "free" | "active" | "past_due" | "canceled";
   is_pro: boolean;
   default_layout: LayoutMode;
+  triage_reminder_enabled: boolean;
+  triage_reminder_hour: number;
 }
 
 // Billing

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -67,6 +67,8 @@ export async function createTask(body: {
   domain_id?: string;
   parent_id?: string;
   skip_triage_stamp?: boolean;
+  important?: boolean;
+  urgent?: boolean;
 }): Promise<Task> {
   return request<Task>("tasks", { method: "POST", body: JSON.stringify(body) });
 }
@@ -164,6 +166,8 @@ export async function getMe(): Promise<User> {
 export async function updateMe(body: {
   has_completed_onboarding?: boolean;
   default_layout?: LayoutMode;
+  triage_reminder_enabled?: boolean;
+  triage_reminder_hour?: number;
 }): Promise<User> {
   return request<User>("me", { method: "PATCH", body: JSON.stringify(body) });
 }


### PR DESCRIPTION
## Summary

Three small UX fixes from a triage round:

- **Triage reminder is now optional**: banner has Start triage / Skip today / Turn off reminders. Skip today is a *hard skip* (localStorage, survives tab close); Turn off persists via `PATCH /me { triage_reminder_enabled: false }`. The fields were added to the User model in #172/#176 but the frontend never read them — this wires it up. Also adds a toggle on the Settings page so users can re-enable.
- **Domain picker no longer gets clipped at the top**: measures available space on open and flips upward when there's <80px below.
- **Task input now affords important/urgent at creation**: `!` and ⚡ toggle buttons (plus keyboard shortcuts `!` and `u`) appear in phase 2 of the input, mirroring the task-item pattern. Tasks now land in the right quadrant immediately instead of needing a follow-up hover-tap.

## Test plan

- [ ] Triage banner shows on Today; Skip today dismisses for the day even after tab close; reopening tab does not re-show
- [ ] Turn off reminders dismisses banner permanently; re-enable from Settings → Triage reminders works
- [ ] Domain picker: open on a task at the top of the viewport (e.g., first task in Quadrant view) — picker opens upward
- [ ] Create a task: type → Enter → press `!` → press `u` → Enter → confirm task lands in DO FIRST (Q1)
- [ ] Click `!`/⚡ chips with mouse instead of keys — toggling persists on submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)