### PR TITLE
chore: PR-only CI trigger + concurrency cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 name: CI
 
+# PR-only. The required `check` is produced by the PR run, so re-running on the
+# squash-merge commit (push) was pure duplication. Railway auto-deploys from git
+# push independently of Actions, so deploys are unaffected. See
+# ~/.claude/knowledge-base/github-actions-cost-control.md
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:


### PR DESCRIPTION
Cross-repo Actions cost cleanup. Drop the redundant `push: main` trigger and add `concurrency: cancel-in-progress` to `ci.yml`. The required `check` is satisfied by the PR run; Railway auto-deploys independently of Actions. Full playbook: `~/.claude/knowledge-base/github-actions-cost-control.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)