### PR TITLE
Add DroppableBucketTabs component for cross-bucket drag (#185)

### DIFF
--- a/frontend/src/components/layouts/droppable-bucket-tabs.tsx
+++ b/frontend/src/components/layouts/droppable-bucket-tabs.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useDroppable } from "@dnd-kit/core";
+import type { BucketType, Task } from "@/lib/api-types";
+
+interface DroppableBucketTabsProps {
+  tasks: Task[];
+  activeBucket: BucketType;
+  onBucketChange: (b: BucketType) => void;
+}
+
+const TABS: { value: BucketType; label: string }[] = [
+  { value: "today", label: "Today" },
+  { value: "soon", label: "Soon" },
+  { value: "later", label: "Later" },
+  { value: "someday", label: "Someday" },
+];
+
+interface DroppableTabProps {
+  value: BucketType;
+  label: string;
+  count: number;
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+/**
+ * A single bucket tab that is also a dnd-kit drop target. Dropping a dragged
+ * task here changes its `bucket` (handled by the parent's onDragEnd, which
+ * reads `data.bucket`). Kept as its own component so `useDroppable` is called
+ * once per tab rather than inside a loop.
+ */
+function DroppableTab({ value, label, count, isActive, onSelect }: DroppableTabProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `bucket-${value}`,
+    data: { kind: "bucket", bucket: value },
+  });
+
+  return (
+    <button
+      ref={setNodeRef}
+      onClick={onSelect}
+      className={[
+        "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+        isActive
+          ? "bg-bg-hover text-text-primary"
+          : "text-text-muted hover:text-text-secondary hover:bg-bg-hover/50",
+        isOver ? "ring-2 ring-accent-blue ring-inset" : "",
+      ].join(" ")}
+    >
+      {label}
+      {count > 0 && <span className="text-[11px] text-text-muted tabular-nums">{count}</span>}
+    </button>
+  );
+}
+
+/**
+ * Drag-and-drop-aware variant of BucketTabs for the Quadrant layout. Must be
+ * rendered inside a DndContext (useDroppable requires one). The shared
+ * BucketTabs is left DnD-free for layouts without a DndContext (e.g. Grouped).
+ */
+export function DroppableBucketTabs({ tasks, activeBucket, onBucketChange }: DroppableBucketTabsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      {TABS.map((tab) => {
+        const count = tasks.filter((t) => t.status === "pending" && t.bucket === tab.value).length;
+        return (
+          <DroppableTab
+            key={tab.value}
+            value={tab.value}
+            label={tab.label}
+            count={count}
+            isActive={activeBucket === tab.value}
+            onSelect={() => onBucketChange(tab.value)}
+          />
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## What
New `frontend/src/components/layouts/droppable-bucket-tabs.tsx` — a drag-and-drop-aware variant of the shared `BucketTabs`. Each tab is a `useDroppable` target with `data: { kind: "bucket", bucket }`, so dropping a dragged task on a tab will rebucket it (the actual move is handled by `QuadrantLayout`'s `onDragEnd` in #187). Shows a ring while hovered (`isOver`).

Design notes:
- Same props, tabs, labels, and pending-count badges as `BucketTabs`.
- Each tab is its own `DroppableTab` component so `useDroppable` is called once per tab, not in a loop (Rules of Hooks).
- The shared `BucketTabs` is left untouched / DnD-free, since it's also used by the Grouped layout which has no `DndContext` ancestor (`useDroppable` requires one).

Must be rendered inside a `DndContext`. Wired into `QuadrantLayout` in #187. Ships unused.

## Verification
- `npm run lint` — clean
- `npx tsc --noEmit` — clean

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)