### PR TITLE
Polish quadrant drag-and-drop: DragOverlay ghost + reduced-motion (#188)

### DIFF
--- a/frontend/src/components/draggable-task-item.tsx
+++ b/frontend/src/components/draggable-task-item.tsx
@@ -32,7 +32,7 @@ export function DraggableTaskItem({ task, domains, onMutate }: DraggableTaskItem
       <button
         {...attributes}
         {...listeners}
-        className="shrink-0 w-5 flex items-center justify-center cursor-grab active:cursor-grabbing opacity-30 sm:opacity-0 group-hover/draggable:opacity-100 hover:!opacity-100 transition-opacity text-text-muted hover:text-text-secondary touch-none"
+        className="shrink-0 w-5 flex items-center justify-center cursor-grab active:cursor-grabbing opacity-30 sm:opacity-0 group-hover/draggable:opacity-100 hover:!opacity-100 transition-opacity motion-reduce:transition-none text-text-muted hover:text-text-secondary touch-none"
         aria-label="Drag to reprioritize"
       >
         <svg width="10" height="14" viewBox="0 0 10 14" fill="currentColor">

--- a/frontend/src/components/layouts/droppable-bucket-tabs.tsx
+++ b/frontend/src/components/layouts/droppable-bucket-tabs.tsx
@@ -41,7 +41,7 @@ function DroppableTab({ value, label, count, isActive, onSelect }: DroppableTabP
       ref={setNodeRef}
       onClick={onSelect}
       className={[
-        "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+        "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors motion-reduce:transition-none",
         isActive
           ? "bg-bg-hover text-text-primary"
           : "text-text-muted hover:text-text-secondary hover:bg-bg-hover/50",

--- a/frontend/src/components/layouts/quadrant-layout.tsx
+++ b/frontend/src/components/layouts/quadrant-layout.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   DndContext,
+  DragOverlay,
   type DragEndEvent,
+  type DragStartEvent,
   KeyboardSensor,
   PointerSensor,
   TouchSensor,
@@ -102,7 +104,7 @@ function QuadrantCell({ quadrant: q, tasks, domains, onMutate }: QuadrantCellPro
   return (
     <div
       ref={setNodeRef}
-      className={`rounded-lg border ${q.borderColor} overflow-hidden transition-shadow ${
+      className={`rounded-lg border ${q.borderColor} overflow-hidden transition-shadow motion-reduce:transition-none ${
         isOver ? "ring-2 ring-accent-blue ring-inset" : ""
       }`}
     >
@@ -155,13 +157,22 @@ export function QuadrantLayout({
     (t) => t.status === "pending" && t.bucket === activeBucket,
   );
 
+  // Id of the task currently being dragged — drives the DragOverlay preview.
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const activeTask = activeId ? effectiveTasks.find((t) => t.id === activeId) : null;
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
     useSensor(KeyboardSensor),
   );
 
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(String(event.active.id));
+  }
+
   async function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null);
     const { active, over } = event;
     if (!over) return;
 
@@ -198,7 +209,13 @@ export function QuadrantLayout({
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={pointerWithin} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithin}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveId(null)}
+    >
       <div className="flex flex-col gap-4">
         <DroppableBucketTabs
           tasks={tasks}
@@ -261,6 +278,16 @@ export function QuadrantLayout({
           </div>
         </div>
       </div>
+
+      {/* Floating preview that follows the cursor while dragging. Rendered in a
+          portal, so it isn't clipped by a cell's overflow-hidden. */}
+      <DragOverlay dropAnimation={null}>
+        {activeTask ? (
+          <div className="max-w-xs cursor-grabbing rounded-md border border-border bg-bg-secondary px-3 py-2 text-sm text-text-primary shadow-lg">
+            {activeTask.text}
+          </div>
+        ) : null}
+      </DragOverlay>
     </DndContext>
   );
 }


### PR DESCRIPTION
## What
Final polish on the Quadrant drag-and-drop interaction.

- **DragOverlay ghost:** a floating preview of the dragged task now follows the cursor (previously the source just dimmed and nothing moved). Tracked via `activeId` set on `onDragStart` and cleared on `onDragEnd`/`onDragCancel`. Rendered in a portal, so it isn't clipped by a cell's `overflow-hidden`. `dropAnimation={null}` keeps the drop crisp.
- **Reduced motion:** `motion-reduce:transition-none` on the transitions this feature introduced — quadrant cells (`transition-shadow`), the drag handle (`transition-opacity`), and bucket tabs (`transition-colors`).

### Already shipped earlier in the stack (verified, no rework)
- Hover highlight: cell `isOver` ring (#186) + tab `isOver` ring (#185).
- Error rollback: `try/catch` + `onMutate()` refetch (#187).
- A11y: grip handle `aria-label="Drag to reprioritize"` + `KeyboardSensor` wired; dnd-kit's default screen-reader announcements apply.
- Touch: `TouchSensor` long-press (delay 200/tolerance 5) preserves in-cell scroll.

## Verification
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — passes

Manual device QA for touch drag is the one thing not coverable in CI; the sensor config matches the already-shipped Today-list touch drag.

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)