### PR TITLE
Generalize task position ordering to all buckets (#195)

### DIFF
--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -22,6 +22,21 @@ def _load_related(query: SelectOfScalar[Task]) -> SelectOfScalar[Task]:
     return query.options(selectinload(Task.domain), selectinload(Task.children))
 
 
+def _next_position(db: Session, user_id: uuid.UUID, bucket: BucketType) -> int:
+    """Append position for a new/moved top-level task: max(position)+1 within the
+    bucket's pending top-level tasks, or 0 if the bucket is empty. Every bucket
+    keeps its own ordering (not just Today)."""
+    max_pos = db.exec(
+        select(func.max(Task.position)).where(
+            Task.user_id == user_id,
+            Task.bucket == bucket,
+            Task.status == TaskStatus.pending,
+            Task.parent_id.is_(None),
+        )
+    ).first()
+    return (max_pos + 1) if max_pos is not None else 0
+
+
 def create_task(
     db: Session,
     user_id: uuid.UUID,
@@ -80,18 +95,11 @@ def create_task(
         bucket = BucketType(parent.bucket)
         domain_id = parent.domain_id
 
-    # For top-level Today tasks, assign position after existing ordered tasks
+    # Top-level tasks get an append position within their bucket (every bucket,
+    # not just Today). Subtasks stay unordered (position stays None).
     position = None
-    if bucket == BucketType.today and parent_id is None:
-        max_pos = db.exec(
-            select(func.max(Task.position)).where(
-                Task.user_id == user_id,
-                Task.bucket == BucketType.today,
-                Task.status == TaskStatus.pending,
-                Task.parent_id.is_(None),
-            )
-        ).first()
-        position = (max_pos + 1) if max_pos is not None else 0
+    if parent_id is None:
+        position = _next_position(db, user_id, bucket)
 
     task = Task(
         user_id=user_id,
@@ -132,14 +140,13 @@ def get_tasks(
     if domain_id is not None:
         query = query.where(Task.domain_id == domain_id)
 
-    if bucket == BucketType.today:
-        query = _load_related(query).order_by(
-            case((Task.position.is_(None), 1), else_=0),  # nulls last
-            Task.position.asc(),
-            Task.created_at.desc(),
-        )
-    else:
-        query = _load_related(query).order_by(Task.created_at.desc())
+    # Every bucket is position-ordered (nulls last, then newest). Legacy tasks
+    # with no position sort after positioned ones until first reordered.
+    query = _load_related(query).order_by(
+        case((Task.position.is_(None), 1), else_=0),  # nulls last
+        Task.position.asc(),
+        Task.created_at.desc(),
+    )
     return list(db.exec(query).all())
 
 
@@ -195,9 +202,12 @@ def update_task(
                 status_code=422,
             )
         task.text = text.strip()
-    if bucket is not None:
-        if task.bucket == BucketType.today and bucket != BucketType.today:
-            task.position = None
+    if bucket is not None and bucket != task.bucket:
+        # Moving buckets: append to the destination's order. Position isn't
+        # carried across buckets (no meaningful rank to preserve), per the
+        # "order is sacred" model — only explicit reorder sets a rank.
+        if task.parent_id is None:
+            task.position = _next_position(db, user_id, bucket)
         task.bucket = bucket
     if domain_id is not _UNSET:
         task.domain_id = domain_id

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -154,8 +154,17 @@ class TestTodayOrdering:
         texts = [t["text"] for t in r.json()]
         assert texts == ["First", "Second", "Third", "No position"]
 
-    def test_position_cleared_when_moved_out_of_today(self, client, db, test_user):
-        """Moving a task out of Today should clear its position."""
+    def test_position_appended_to_new_bucket_when_moved(self, client, db, test_user):
+        """Moving a task to another bucket appends it to that bucket's order
+        (no longer clears position) — shared-ordering model."""
+        # Destination bucket already has one positioned task.
+        existing = Task(
+            user_id=test_user.id,
+            text="Already in soon",
+            bucket=BucketType.soon,
+            status=TaskStatus.pending,
+            position=0,
+        )
         t = Task(
             user_id=test_user.id,
             text="Positioned",
@@ -163,7 +172,7 @@ class TestTodayOrdering:
             status=TaskStatus.pending,
             position=2,
         )
-        db.add(t)
+        db.add_all([existing, t])
         db.flush()
 
         r = client.patch(f"/tasks/{t.id}", json={"bucket": "soon"})
@@ -171,34 +180,54 @@ class TestTodayOrdering:
 
         db.expire_all()
         updated = db.get(Task, t.id)
-        assert updated.position is None
         assert updated.bucket == "soon"
+        # Appended after the existing soon task (position 0) → position 1.
+        assert updated.position == 1
 
-    def test_non_today_bucket_ignores_position(self, client, db, test_user):
-        """Bucket views other than Today should not use position ordering."""
+    def test_non_today_bucket_ordered_by_position(self, client, db, test_user):
+        """Every bucket (not just Today) is position-ordered, nulls last."""
         from datetime import datetime, timedelta
 
         t1 = Task(
             user_id=test_user.id,
-            text="Older",
+            text="Second",
+            bucket=BucketType.soon,
+            position=1,
+            created_at=datetime.utcnow(),
+        )
+        t2 = Task(
+            user_id=test_user.id,
+            text="First",
             bucket=BucketType.soon,
             position=0,
             created_at=datetime.utcnow() - timedelta(hours=1),
         )
-        t2 = Task(
+        t3 = Task(
             user_id=test_user.id,
-            text="Newer",
+            text="No position",
             bucket=BucketType.soon,
-            position=5,
-            created_at=datetime.utcnow(),
+            position=None,
+            created_at=datetime.utcnow() - timedelta(hours=2),
         )
-        db.add_all([t1, t2])
+        db.add_all([t1, t2, t3])
         db.flush()
 
         r = client.get("/tasks", params={"bucket": "soon"})
         texts = [t["text"] for t in r.json()]
-        # created_at DESC — newer first
-        assert texts == ["Newer", "Older"]
+        # position ASC, nulls last
+        assert texts == ["First", "Second", "No position"]
+
+    def test_create_in_non_today_bucket_gets_append_position(self, client, db, test_user):
+        """New top-level tasks get an append position in any bucket."""
+        r1 = client.post("/tasks", json={"text": "First later", "bucket": "later"})
+        r2 = client.post("/tasks", json={"text": "Second later", "bucket": "later"})
+        assert r1.status_code == 201 and r2.status_code == 201
+
+        db.expire_all()
+        first = db.get(Task, uuid.UUID(r1.json()["id"]))
+        second = db.get(Task, uuid.UUID(r2.json()["id"]))
+        assert first.position == 0
+        assert second.position == 1
 
 
 class TestReorderTasks:


### PR DESCRIPTION
## What
Backend foundation for shared-ordering drag-and-drop: `Task.position` now orders **every** bucket, not just Today. No schema change (`position` already existed).

- **`_next_position()` helper** — `max(position)+1` within a bucket's pending top-level tasks (0 if empty).
- **`create_task`** — assigns an append position for top-level tasks in any bucket (was Today-only).
- **`get_tasks`** — orders every bucket by `position` (nulls last) then `created_at desc` (was: only Today used position; others used `created_at desc`).
- **`update_task`** — on a bucket change, appends the task to the destination bucket's order instead of nulling `position`. Same-bucket attribute changes leave `position` alone ("order is sacred").

## Consumer audit (acceptance criterion)
Only `GET /tasks` (`api/tasks.py:58`) consumes `get_tasks`. Triage and wind-down run their **own** queries (`triage_service` orders `created_at.asc()` independently); composter/briefing/mit use `created_at` only for age math. So the ordering change is contained to the task-list endpoint the layouts use — no unintended behavior change elsewhere.

## Legacy data
Tasks with `position = None` (non-Today tasks created before this) sort last by `created_at`. They get real positions the first time their bucket is reordered (#196). No backfill migration required for correctness.

## Tests
- Updated two tests that encoded the old behavior (clear-position-on-move → now append; non-Today-ignores-position → now position-ordered).
- Added: non-Today create gets append position, non-Today bucket ordered by position (nulls last), cross-bucket move appends.
- **175 passed**, `ruff check`/`format` clean.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)