### PR TITLE
Generalize reorder_tasks endpoint to any bucket (#196)

### DIFF
--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -108,7 +108,7 @@ def reorder_tasks(
     db: Session = Depends(get_db),
     user_id: uuid.UUID = Depends(get_current_user_id),
 ):
-    count = task_service.reorder_tasks(db, user_id, body.task_ids)
+    count = task_service.reorder_tasks(db, user_id, body.task_ids, body.bucket)
     return {"updated": count}
 
 

--- a/backend/app/schemas/task_schemas.py
+++ b/backend/app/schemas/task_schemas.py
@@ -34,6 +34,7 @@ class TaskUpdate(BaseModel):
 
 class ReorderRequest(BaseModel):
     task_ids: list[uuid.UUID]
+    bucket: BucketType = BucketType.today
 
     @field_validator("task_ids")
     @classmethod

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -272,44 +272,29 @@ def complete_task(db: Session, user_id: uuid.UUID, task_id: uuid.UUID) -> Task:
     return task
 
 
-def reorder_tasks(db: Session, user_id: uuid.UUID, task_ids: list[uuid.UUID]) -> int:
-    # Verify all pending Today tasks are included
-    all_today = list(
+def reorder_tasks(
+    db: Session, user_id: uuid.UUID, task_ids: list[uuid.UUID], bucket: BucketType
+) -> int:
+    # Verify the id set matches all pending top-level tasks in the given bucket.
+    all_in_bucket = list(
         db.exec(
             select(Task).where(
                 Task.user_id == user_id,
-                Task.bucket == BucketType.today,
+                Task.bucket == bucket,
                 Task.status == TaskStatus.pending,
                 Task.parent_id.is_(None),
             )
         ).all()
     )
-    all_today_ids = {t.id for t in all_today}
-    if set(task_ids) != all_today_ids:
+    all_bucket_ids = {t.id for t in all_in_bucket}
+    if set(task_ids) != all_bucket_ids:
         raise AppError(
             code="incomplete_reorder",
-            message="All pending Today tasks must be included in reorder",
+            message=f"All pending {bucket} tasks must be included in reorder",
             status_code=400,
         )
 
-    tasks = list(db.exec(select(Task).where(Task.id.in_(task_ids), Task.user_id == user_id)).all())
-    task_map = {t.id: t for t in tasks}
-
-    for task_id in task_ids:
-        if task_id not in task_map:
-            raise AppError(
-                code="invalid_task",
-                message=f"Task {task_id} not found or does not belong to you",
-                status_code=400,
-            )
-        task = task_map[task_id]
-        if task.bucket != BucketType.today or task.status != TaskStatus.pending:
-            raise AppError(
-                code="invalid_task",
-                message=f"Task {task_id} is not a pending Today task",
-                status_code=400,
-            )
-
+    task_map = {t.id: t for t in all_in_bucket}
     for i, task_id in enumerate(task_ids):
         task_map[task_id].position = i
         db.add(task_map[task_id])

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -340,6 +340,57 @@ class TestReorderTasks:
         r = client.patch("/tasks/reorder", json={"task_ids": [str(t.id)]})
         assert r.status_code == 400
 
+    def test_reorder_non_today_bucket(self, client, db, test_user):
+        """Reorder works for any bucket, not just Today."""
+        tasks = []
+        for text in ["A", "B", "C"]:
+            t = Task(
+                user_id=test_user.id, text=text, bucket=BucketType.soon, status=TaskStatus.pending
+            )
+            db.add(t)
+            tasks.append(t)
+        db.flush()
+
+        r = client.patch(
+            "/tasks/reorder",
+            json={
+                "bucket": "soon",
+                "task_ids": [str(tasks[2].id), str(tasks[0].id), str(tasks[1].id)],
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["updated"] == 3
+
+        r2 = client.get("/tasks", params={"bucket": "soon"})
+        assert [t["text"] for t in r2.json()] == ["C", "A", "B"]
+
+    def test_reorder_rejects_partial_list_in_bucket(self, client, db, test_user):
+        """Returns 400 if not all pending tasks of the given bucket are included."""
+        t1 = Task(user_id=test_user.id, text="A", bucket=BucketType.soon, status=TaskStatus.pending)
+        t2 = Task(user_id=test_user.id, text="B", bucket=BucketType.soon, status=TaskStatus.pending)
+        db.add_all([t1, t2])
+        db.flush()
+        r = client.patch("/tasks/reorder", json={"bucket": "soon", "task_ids": [str(t1.id)]})
+        assert r.status_code == 400
+
+    def test_reorder_rejects_task_from_other_bucket(self, client, db, test_user):
+        """A task in a different bucket than the one being reordered is rejected
+        (the id set won't match the target bucket's tasks)."""
+        soon_task = Task(
+            user_id=test_user.id, text="Soon", bucket=BucketType.soon, status=TaskStatus.pending
+        )
+        today_task = Task(
+            user_id=test_user.id, text="Today", bucket=BucketType.today, status=TaskStatus.pending
+        )
+        db.add_all([soon_task, today_task])
+        db.flush()
+        # Reordering bucket 'soon' but passing a today task → set mismatch → 400.
+        r = client.patch(
+            "/tasks/reorder",
+            json={"bucket": "soon", "task_ids": [str(soon_task.id), str(today_task.id)]},
+        )
+        assert r.status_code == 400
+
 
 class TestTaskNotes:
     def test_create_task_with_notes(self, client, test_user):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -92,10 +92,13 @@ export async function setMIT(taskId: string): Promise<Task> {
   return request<Task>(`tasks/${taskId}/mit`, { method: "POST" });
 }
 
-export async function reorderTasks(taskIds: string[]): Promise<{ updated: number }> {
+export async function reorderTasks(
+  taskIds: string[],
+  bucket: BucketType = "today",
+): Promise<{ updated: number }> {
   return request<{ updated: number }>("tasks/reorder", {
     method: "PATCH",
-    body: JSON.stringify({ task_ids: taskIds }),
+    body: JSON.stringify({ task_ids: taskIds, bucket }),
   });
 }
 


### PR DESCRIPTION
## What
The reorder endpoint can now reorder pending top-level tasks in **any** bucket, not just Today — the "reorder" half of the shared-ordering model.

- **`reorder_tasks(db, user_id, task_ids, bucket)`** — validates `task_ids` exactly matches the pending top-level tasks of the given `bucket`, then writes `position = 0..n`. The set-equality check already enforces ownership (query is user-scoped), bucket membership, pending status, and top-level — so the old per-task validation loop is redundant and removed.
- **`ReorderRequest`** gains `bucket: BucketType = today` (default keeps old payloads valid).
- **`PATCH /tasks/reorder`** forwards `body.bucket`.
- **Frontend `reorderTasks(taskIds, bucket = "today")`** sends `bucket`. The existing List/Today caller is unchanged (default covers it).

## Tests
- Reorder a non-Today (soon) bucket and verify order.
- Partial-set rejection for a non-Today bucket (400).
- Cross-bucket task in the payload → set mismatch → 400.
- Existing Today reorder tests still pass (default bucket).
- **178 passed**, ruff clean, frontend `tsc`/lint clean.

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)