### PR TITLE
Add drag-and-drop to the Matrix layout (#198)

### DIFF
--- a/frontend/src/components/draggable-task-item.tsx
+++ b/frontend/src/components/draggable-task-item.tsx
@@ -9,6 +9,7 @@ interface DraggableTaskItemProps {
   task: Task;
   domains: Domain[];
   onMutate: () => void;
+  compact?: boolean;
 }
 
 /**
@@ -21,7 +22,7 @@ interface DraggableTaskItemProps {
  * (DragOverlay) is layered on in the polish pass; keeping the source in place
  * avoids the card being clipped by the cell's `overflow-hidden`.
  */
-export function DraggableTaskItem({ task, domains, onMutate }: DraggableTaskItemProps) {
+export function DraggableTaskItem({ task, domains, onMutate, compact }: DraggableTaskItemProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
 
   return (
@@ -45,7 +46,7 @@ export function DraggableTaskItem({ task, domains, onMutate }: DraggableTaskItem
         </svg>
       </button>
       <div className="flex-1 ml-1">
-        <TaskItem task={task} domains={domains} onMutate={onMutate} />
+        <TaskItem task={task} domains={domains} onMutate={onMutate} compact={compact} />
       </div>
     </div>
   );

--- a/frontend/src/components/layouts/matrix-layout.tsx
+++ b/frontend/src/components/layouts/matrix-layout.tsx
@@ -1,7 +1,16 @@
 "use client";
 
+import {
+  DndContext,
+  DragOverlay,
+  type DragEndEvent,
+  pointerWithin,
+  useDroppable,
+} from "@dnd-kit/core";
 import type { Task, Domain, BucketType } from "@/lib/api-types";
-import { TaskItem } from "@/components/task-item";
+import { updateTask } from "@/lib/api";
+import { DraggableTaskItem } from "@/components/draggable-task-item";
+import { useOptimisticTaskDnd } from "@/components/layouts/use-optimistic-task-dnd";
 
 const BUCKETS: { value: BucketType; label: string; sublabel: string }[] = [
   { value: "today", label: "Today", sublabel: "do it today" },
@@ -18,6 +27,55 @@ interface MatrixLayoutProps {
   onMutate: () => void;
 }
 
+interface MatrixCellProps {
+  domainId: string | null;
+  bucket: BucketType;
+  tasks: Task[];
+  domains: Domain[];
+  onMutate: () => void;
+  isColDimmed: boolean;
+}
+
+/**
+ * One (domain × bucket) intersection — a drop target carrying both coordinates.
+ * Dropping a card here sets its `domain_id` AND `bucket` in one move. Its own
+ * component so `useDroppable` runs once per cell (Rules of Hooks). Empty cells
+ * stay valid targets.
+ */
+function MatrixCell({ domainId, bucket, tasks, domains, onMutate, isColDimmed }: MatrixCellProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `cell-${domainId ?? "none"}-${bucket}`,
+    data: { kind: "cell", domainId, bucket },
+  });
+
+  return (
+    <td
+      ref={setNodeRef}
+      className={[
+        "border border-border p-0 align-top transition-[opacity,box-shadow] motion-reduce:transition-none",
+        isColDimmed ? "opacity-30" : "",
+        isOver ? "ring-2 ring-accent-blue ring-inset" : "",
+      ].join(" ")}
+    >
+      {tasks.length === 0 ? (
+        <span className="text-text-muted text-center block py-3">—</span>
+      ) : (
+        <div>
+          {tasks.map((task) => (
+            <DraggableTaskItem
+              key={task.id}
+              task={task}
+              domains={domains}
+              onMutate={onMutate}
+              compact
+            />
+          ))}
+        </div>
+      )}
+    </td>
+  );
+}
+
 export function MatrixLayout({
   tasks,
   domains,
@@ -25,9 +83,48 @@ export function MatrixLayout({
   onBucketChange,
   onMutate,
 }: MatrixLayoutProps) {
-  const pending = tasks.filter((t) => t.status === "pending");
+  const { effectiveTasks, applyOverride, sensors, setActiveId, activeTask } =
+    useOptimisticTaskDnd(tasks);
 
+  const pending = effectiveTasks.filter((t) => t.status === "pending");
   const bucketCount = (b: BucketType) => pending.filter((t) => t.bucket === b).length;
+  const cellTasks = (domainId: string | null, b: BucketType) =>
+    pending.filter((t) => (t.domain?.id ?? null) === domainId && t.bucket === b);
+
+  // Rows: every domain + a "No domain" row, always rendered so cells are valid
+  // drop targets even when empty.
+  const rows: Array<{ domain: Domain | null }> = [
+    ...domains.map((d) => ({ domain: d })),
+    { domain: null },
+  ];
+
+  async function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null);
+    const { active, over } = event;
+    if (!over) return;
+
+    const taskId = String(active.id);
+    const task = pending.find((t) => t.id === taskId);
+    if (!task) return;
+
+    const data = over.data.current;
+    if (data?.kind !== "cell") return;
+
+    const { domainId, bucket } = data as { domainId: string | null; bucket: BucketType };
+    // Already in this cell — no change.
+    if ((task.domain?.id ?? null) === domainId && task.bucket === bucket) return;
+
+    const targetDomain = domainId ? (domains.find((d) => d.id === domainId) ?? null) : null;
+    applyOverride(taskId, { domain: targetDomain, bucket });
+    try {
+      await updateTask(taskId, { domain_id: domainId, bucket });
+    } catch (err) {
+      console.error("Failed to move task in matrix:", err);
+    }
+    onMutate();
+  }
+
+  const isEmpty = domains.length === 0 && pending.filter((t) => t.domain === null).length === 0;
 
   return (
     <>
@@ -38,7 +135,7 @@ export function MatrixLayout({
       </div>
 
       <div className="hidden md:block overflow-x-auto">
-        {domains.length === 0 && pending.filter((t) => t.domain === null).length === 0 ? (
+        {isEmpty ? (
           <div className="rounded-lg border border-border bg-bg-secondary px-4 py-10 text-center">
             <p className="text-sm text-text-secondary">Nothing on your plate.</p>
             <p className="text-xs text-text-muted mt-1">
@@ -46,135 +143,94 @@ export function MatrixLayout({
             </p>
           </div>
         ) : (
-          <table className="w-full border-collapse text-xs">
-            <thead>
-              <tr>
-                <th className="border border-border bg-bg-secondary p-2 text-left min-w-[100px]">
-                  <span className="text-[10px] text-text-muted font-mono uppercase tracking-wide">
-                    Domain ↓ / Time →
-                  </span>
-                </th>
-                {BUCKETS.map((b) => {
-                  const isActive = activeBucket === b.value;
-                  const isDimmed = activeBucket !== null && !isActive;
-                  const count = bucketCount(b.value);
-                  return (
-                    <th
-                      key={b.value}
-                      className={[
-                        "border border-border p-2 text-left font-medium min-w-[200px] cursor-pointer select-none",
-                        "transition-colors",
-                        isActive
-                          ? "bg-accent-blue/10 text-accent-blue"
-                          : isDimmed
-                            ? "bg-bg-secondary text-text-muted opacity-40"
-                            : "bg-bg-secondary text-text-secondary hover:bg-bg-hover",
-                      ].join(" ")}
-                      onClick={() => onBucketChange(isActive ? null : b.value)}
-                    >
-                      <div className="font-semibold text-sm">{b.label}</div>
-                      <div className="text-[10px] text-text-muted font-normal mt-0.5">
-                        {b.sublabel} · {count}
-                      </div>
-                    </th>
-                  );
-                })}
-              </tr>
-            </thead>
-            <tbody>
-              {domains.map((domain) => {
-                const domainTasks = pending.filter((t) => t.domain?.id === domain.id);
-                return (
-                  <tr key={domain.id}>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={pointerWithin}
+            onDragStart={(e) => setActiveId(String(e.active.id))}
+            onDragEnd={handleDragEnd}
+            onDragCancel={() => setActiveId(null)}
+          >
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr>
+                  <th className="border border-border bg-bg-secondary p-2 text-left min-w-[100px]">
+                    <span className="text-[10px] text-text-muted font-mono uppercase tracking-wide">
+                      Domain ↓ / Time →
+                    </span>
+                  </th>
+                  {BUCKETS.map((b) => {
+                    const isActive = activeBucket === b.value;
+                    const isDimmed = activeBucket !== null && !isActive;
+                    const count = bucketCount(b.value);
+                    return (
+                      <th
+                        key={b.value}
+                        className={[
+                          "border border-border p-2 text-left font-medium min-w-[200px] cursor-pointer select-none",
+                          "transition-colors",
+                          isActive
+                            ? "bg-accent-blue/10 text-accent-blue"
+                            : isDimmed
+                              ? "bg-bg-secondary text-text-muted opacity-40"
+                              : "bg-bg-secondary text-text-secondary hover:bg-bg-hover",
+                        ].join(" ")}
+                        onClick={() => onBucketChange(isActive ? null : b.value)}
+                      >
+                        <div className="font-semibold text-sm">{b.label}</div>
+                        <div className="text-[10px] text-text-muted font-normal mt-0.5">
+                          {b.sublabel} · {count}
+                        </div>
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.domain?.id ?? "none"}>
                     <td className="border border-border bg-bg-secondary p-2 align-top">
                       <div className="flex items-center gap-1.5 pt-1">
                         <span
                           className="h-2 w-2 rounded-full shrink-0"
-                          style={{ backgroundColor: domain.color }}
+                          style={{
+                            backgroundColor: row.domain ? row.domain.color : "var(--color-border)",
+                          }}
                         />
-                        <span className="text-text-secondary text-xs font-medium truncate max-w-[80px]">
-                          {domain.name}
+                        <span
+                          className={
+                            row.domain
+                              ? "text-text-secondary text-xs font-medium truncate max-w-[80px]"
+                              : "text-text-muted text-xs"
+                          }
+                        >
+                          {row.domain?.name ?? "No domain"}
                         </span>
                       </div>
                     </td>
-                    {BUCKETS.map((b) => {
-                      const cellTasks = domainTasks.filter((t) => t.bucket === b.value);
-                      const isColDimmed = activeBucket !== null && activeBucket !== b.value;
-                      return (
-                        <td
-                          key={b.value}
-                          className={[
-                            "border border-border p-0 align-top transition-opacity",
-                            isColDimmed ? "opacity-30" : "",
-                          ].join(" ")}
-                        >
-                          {cellTasks.length === 0 ? (
-                            <span className="text-text-muted text-center block py-3">—</span>
-                          ) : (
-                            <div>
-                              {cellTasks.map((task) => (
-                                <TaskItem
-                                  key={task.id}
-                                  task={task}
-                                  domains={domains}
-                                  onMutate={onMutate}
-                                  compact
-                                />
-                              ))}
-                            </div>
-                          )}
-                        </td>
-                      );
-                    })}
+                    {BUCKETS.map((b) => (
+                      <MatrixCell
+                        key={b.value}
+                        domainId={row.domain?.id ?? null}
+                        bucket={b.value}
+                        tasks={cellTasks(row.domain?.id ?? null, b.value)}
+                        domains={domains}
+                        onMutate={onMutate}
+                        isColDimmed={activeBucket !== null && activeBucket !== b.value}
+                      />
+                    ))}
                   </tr>
-                );
-              })}
+                ))}
+              </tbody>
+            </table>
 
-              {(() => {
-                const undomained = pending.filter((t) => t.domain === null);
-                if (undomained.length === 0) return null;
-                return (
-                  <tr>
-                    <td className="border border-border bg-bg-secondary p-2 align-top">
-                      <div className="flex items-center gap-1.5 pt-1">
-                        <span className="h-2 w-2 rounded-full shrink-0 bg-border" />
-                        <span className="text-text-muted text-xs">No domain</span>
-                      </div>
-                    </td>
-                    {BUCKETS.map((b) => {
-                      const cellTasks = undomained.filter((t) => t.bucket === b.value);
-                      const isColDimmed = activeBucket !== null && activeBucket !== b.value;
-                      return (
-                        <td
-                          key={b.value}
-                          className={[
-                            "border border-border p-0 align-top transition-opacity",
-                            isColDimmed ? "opacity-30" : "",
-                          ].join(" ")}
-                        >
-                          {cellTasks.length === 0 ? (
-                            <span className="text-text-muted text-center block py-3">—</span>
-                          ) : (
-                            <div>
-                              {cellTasks.map((task) => (
-                                <TaskItem
-                                  key={task.id}
-                                  task={task}
-                                  domains={domains}
-                                  onMutate={onMutate}
-                                  compact
-                                />
-                              ))}
-                            </div>
-                          )}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                );
-              })()}
-            </tbody>
-          </table>
+            <DragOverlay dropAnimation={null}>
+              {activeTask ? (
+                <div className="max-w-xs cursor-grabbing rounded-md border border-border bg-bg-secondary px-3 py-2 text-sm text-text-primary shadow-lg">
+                  {activeTask.text}
+                </div>
+              ) : null}
+            </DragOverlay>
+          </DndContext>
         )}
       </div>
     </>


### PR DESCRIPTION
## What
Drag-and-drop in the Matrix (domain × bucket) layout — the only 2-D reclassify.

- **Each cell is a drop target** (`MatrixCell` + `useDroppable`) carrying `data: { kind: "cell", domainId, bucket }`. Dropping a card sets **both** `domain_id` and `bucket` in a single `updateTask`. Same-cell drop is a no-op.
- **Compact cards are draggable** — `DraggableTaskItem` gains a `compact` passthrough to `TaskItem`.
- **Rows always render** (every domain + "No domain") so empty cells are valid drop targets.
- Reuses **`useOptimisticTaskDnd`** (#197) for the optimistic overlay, sensors, and DragOverlay ghost. `isOver` highlight on the hovered cell; `motion-reduce` guards; error rollback via `onMutate()`.
- **Desktop-only preserved** — `DndContext` wraps only the `hidden md:block` table; the mobile message is untouched and carries no DnD wiring.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — passes

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)