### PR TITLE
Add within-group reordering to Grouped/Quadrant/Matrix (#203)

### DIFF
--- a/frontend/src/components/draggable-task-item.tsx
+++ b/frontend/src/components/draggable-task-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDraggable } from "@dnd-kit/core";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
 import type { Task, Domain } from "@/lib/api-types";
 import { TaskItem } from "@/components/task-item";
 import { cn } from "@/lib/utils";
@@ -24,12 +24,25 @@ interface DraggableTaskItemProps {
  */
 export function DraggableTaskItem({ task, domains, onMutate, compact }: DraggableTaskItemProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
+  // The card is also a drop target so a card dropped onto it (same group) can
+  // reorder. The insertion line shows where the dragged card will land.
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: `card-${task.id}`,
+    data: { kind: "reorder-card", taskId: task.id },
+  });
+  const setRefs = (el: HTMLDivElement | null) => {
+    setNodeRef(el);
+    setDropRef(el);
+  };
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
       className={cn("relative flex items-center group/draggable", isDragging && "opacity-50 z-50")}
     >
+      {isOver && !isDragging && (
+        <div className="absolute -top-px left-0 right-0 h-0.5 bg-accent-blue z-10" />
+      )}
       <button
         {...attributes}
         {...listeners}

--- a/frontend/src/components/layouts/grouped-layout.tsx
+++ b/frontend/src/components/layouts/grouped-layout.tsx
@@ -1,17 +1,15 @@
 "use client";
 
-import {
-  DndContext,
-  DragOverlay,
-  type DragEndEvent,
-  pointerWithin,
-  useDroppable,
-} from "@dnd-kit/core";
+import { DndContext, DragOverlay, type DragEndEvent, useDroppable } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
 import type { Task, Domain, BucketType } from "@/lib/api-types";
-import { updateTask } from "@/lib/api";
+import { reorderTasks, updateTask } from "@/lib/api";
 import { DraggableTaskItem } from "@/components/draggable-task-item";
 import { DroppableBucketTabs } from "@/components/layouts/droppable-bucket-tabs";
-import { useOptimisticTaskDnd } from "@/components/layouts/use-optimistic-task-dnd";
+import {
+  reorderAwareCollision,
+  useOptimisticTaskDnd,
+} from "@/components/layouts/use-optimistic-task-dnd";
 
 interface GroupedLayoutProps {
   tasks: Task[];
@@ -80,8 +78,21 @@ export function GroupedLayout({
   activeBucket,
   onBucketChange,
 }: GroupedLayoutProps) {
-  const { effectiveTasks, applyOverride, sensors, setActiveId, activeTask } =
+  const { effectiveTasks, applyOverride, applyReorder, sensors, setActiveId, activeTask } =
     useOptimisticTaskDnd(tasks);
+
+  async function reclassifyDomain(taskId: string, targetDomainId: string | null) {
+    const targetDomain = targetDomainId
+      ? (domains.find((d) => d.id === targetDomainId) ?? null)
+      : null;
+    applyOverride(taskId, { domain: targetDomain });
+    try {
+      await updateTask(taskId, { domain_id: targetDomainId });
+    } catch (err) {
+      console.error("Failed to change domain:", err);
+    }
+    onMutate();
+  }
 
   // Tasks arrive already in shared `position` order from the backend; filtering
   // to the active bucket preserves that order, so we group by domain without
@@ -109,19 +120,33 @@ export function GroupedLayout({
     const data = over.data.current;
     if (!data) return;
 
-    if (data.kind === "domain") {
-      const targetDomainId = (data as { domainId: string | null }).domainId;
-      if ((task.domain?.id ?? null) === targetDomainId) return; // same domain — no-op
-      const targetDomain = targetDomainId
-        ? (domains.find((d) => d.id === targetDomainId) ?? null)
-        : null;
-      applyOverride(taskId, { domain: targetDomain });
+    if (data.kind === "reorder-card") {
+      const overId = (data as { taskId: string }).taskId;
+      if (overId === taskId) return; // dropped on itself
+      const overTask = pending.find((t) => t.id === overId);
+      if (!overTask) return;
+      // Different domain → reclassify into that card's domain. Same domain →
+      // reorder within the active bucket.
+      if ((task.domain?.id ?? null) !== (overTask.domain?.id ?? null)) {
+        await reclassifyDomain(taskId, overTask.domain?.id ?? null);
+        return;
+      }
+      const ids = pending.map((t) => t.id);
+      const from = ids.indexOf(taskId);
+      const to = ids.indexOf(overId);
+      if (from < 0 || to < 0) return;
+      const newOrder = arrayMove(ids, from, to);
+      applyReorder(activeBucket, newOrder);
       try {
-        await updateTask(taskId, { domain_id: targetDomainId });
+        await reorderTasks(newOrder, activeBucket);
       } catch (err) {
-        console.error("Failed to change domain:", err);
+        console.error("Failed to reorder:", err);
       }
       onMutate();
+    } else if (data.kind === "domain") {
+      const targetDomainId = (data as { domainId: string | null }).domainId;
+      if ((task.domain?.id ?? null) === targetDomainId) return; // same domain — no-op
+      await reclassifyDomain(taskId, targetDomainId);
     } else if (data.kind === "bucket") {
       const { bucket } = data as { bucket: BucketType };
       if (task.bucket === bucket) return; // same bucket — no-op
@@ -138,7 +163,7 @@ export function GroupedLayout({
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={pointerWithin}
+      collisionDetection={reorderAwareCollision}
       onDragStart={(e) => setActiveId(String(e.active.id))}
       onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveId(null)}

--- a/frontend/src/components/layouts/matrix-layout.tsx
+++ b/frontend/src/components/layouts/matrix-layout.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import {
-  DndContext,
-  DragOverlay,
-  type DragEndEvent,
-  pointerWithin,
-  useDroppable,
-} from "@dnd-kit/core";
+import { DndContext, DragOverlay, type DragEndEvent, useDroppable } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
 import type { Task, Domain, BucketType } from "@/lib/api-types";
-import { updateTask } from "@/lib/api";
+import { reorderTasks, updateTask } from "@/lib/api";
 import { DraggableTaskItem } from "@/components/draggable-task-item";
-import { useOptimisticTaskDnd } from "@/components/layouts/use-optimistic-task-dnd";
+import {
+  reorderAwareCollision,
+  useOptimisticTaskDnd,
+} from "@/components/layouts/use-optimistic-task-dnd";
 
 const BUCKETS: { value: BucketType; label: string; sublabel: string }[] = [
   { value: "today", label: "Today", sublabel: "do it today" },
@@ -83,7 +81,7 @@ export function MatrixLayout({
   onBucketChange,
   onMutate,
 }: MatrixLayoutProps) {
-  const { effectiveTasks, applyOverride, sensors, setActiveId, activeTask } =
+  const { effectiveTasks, applyOverride, applyReorder, sensors, setActiveId, activeTask } =
     useOptimisticTaskDnd(tasks);
 
   const pending = effectiveTasks.filter((t) => t.status === "pending");
@@ -98,6 +96,17 @@ export function MatrixLayout({
     { domain: null },
   ];
 
+  async function reclassifyCell(taskId: string, domainId: string | null, bucket: BucketType) {
+    const targetDomain = domainId ? (domains.find((d) => d.id === domainId) ?? null) : null;
+    applyOverride(taskId, { domain: targetDomain, bucket });
+    try {
+      await updateTask(taskId, { domain_id: domainId, bucket });
+    } catch (err) {
+      console.error("Failed to move task in matrix:", err);
+    }
+    onMutate();
+  }
+
   async function handleDragEnd(event: DragEndEvent) {
     setActiveId(null);
     const { active, over } = event;
@@ -108,20 +117,40 @@ export function MatrixLayout({
     if (!task) return;
 
     const data = over.data.current;
-    if (data?.kind !== "cell") return;
+    if (!data) return;
 
-    const { domainId, bucket } = data as { domainId: string | null; bucket: BucketType };
-    // Already in this cell — no change.
-    if ((task.domain?.id ?? null) === domainId && task.bucket === bucket) return;
-
-    const targetDomain = domainId ? (domains.find((d) => d.id === domainId) ?? null) : null;
-    applyOverride(taskId, { domain: targetDomain, bucket });
-    try {
-      await updateTask(taskId, { domain_id: domainId, bucket });
-    } catch (err) {
-      console.error("Failed to move task in matrix:", err);
+    if (data.kind === "reorder-card") {
+      const overId = (data as { taskId: string }).taskId;
+      if (overId === taskId) return;
+      const overTask = pending.find((t) => t.id === overId);
+      if (!overTask) return;
+      const sameCell =
+        (task.domain?.id ?? null) === (overTask.domain?.id ?? null) &&
+        task.bucket === overTask.bucket;
+      if (!sameCell) {
+        await reclassifyCell(taskId, overTask.domain?.id ?? null, overTask.bucket);
+        return;
+      }
+      // Reorder within the cell's bucket (position is per-bucket).
+      const ids = pending.filter((t) => t.bucket === task.bucket).map((t) => t.id);
+      const from = ids.indexOf(taskId);
+      const to = ids.indexOf(overId);
+      if (from < 0 || to < 0) return;
+      const newOrder = arrayMove(ids, from, to);
+      applyReorder(task.bucket, newOrder);
+      try {
+        await reorderTasks(newOrder, task.bucket);
+      } catch (err) {
+        console.error("Failed to reorder:", err);
+      }
+      onMutate();
+      return;
     }
-    onMutate();
+
+    if (data.kind !== "cell") return;
+    const { domainId, bucket } = data as { domainId: string | null; bucket: BucketType };
+    if ((task.domain?.id ?? null) === domainId && task.bucket === bucket) return; // same cell
+    await reclassifyCell(taskId, domainId, bucket);
   }
 
   const isEmpty = domains.length === 0 && pending.filter((t) => t.domain === null).length === 0;
@@ -145,7 +174,7 @@ export function MatrixLayout({
         ) : (
           <DndContext
             sensors={sensors}
-            collisionDetection={pointerWithin}
+            collisionDetection={reorderAwareCollision}
             onDragStart={(e) => setActiveId(String(e.active.id))}
             onDragEnd={handleDragEnd}
             onDragCancel={() => setActiveId(null)}

--- a/frontend/src/components/layouts/quadrant-layout.tsx
+++ b/frontend/src/components/layouts/quadrant-layout.tsx
@@ -1,23 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import {
-  DndContext,
-  DragOverlay,
-  type DragEndEvent,
-  type DragStartEvent,
-  KeyboardSensor,
-  PointerSensor,
-  TouchSensor,
-  pointerWithin,
-  useDroppable,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
+import { DndContext, DragOverlay, type DragEndEvent, useDroppable } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
 import type { Task, Domain, BucketType } from "@/lib/api-types";
-import { setPriority, updateTask } from "@/lib/api";
+import { reorderTasks, setPriority, updateTask } from "@/lib/api";
 import { DraggableTaskItem } from "@/components/draggable-task-item";
 import { DroppableBucketTabs } from "@/components/layouts/droppable-bucket-tabs";
+import {
+  reorderAwareCollision,
+  useOptimisticTaskDnd,
+} from "@/components/layouts/use-optimistic-task-dnd";
 
 interface QuadrantLayoutProps {
   tasks: Task[];
@@ -139,36 +131,20 @@ export function QuadrantLayout({
   activeBucket,
   onBucketChange,
 }: QuadrantLayoutProps) {
-  // Optimistic overlay: a drop applies the change locally before the API call
-  // resolves, so the card lands instantly. Cleared once `tasks` reflects the
-  // change (the parent only swaps the `tasks` reference on a refetch, which is
-  // triggered by our own onMutate — so by the time we clear, the real data
-  // already matches the optimistic state and there's no flicker).
-  const [overrides, setOverrides] = useState<
-    Record<string, { important?: boolean; urgent?: boolean; bucket?: BucketType }>
-  >({});
-  useEffect(() => setOverrides({}), [tasks]);
-
-  const effectiveTasks = useMemo(
-    () => tasks.map((t) => (overrides[t.id] ? { ...t, ...overrides[t.id] } : t)),
-    [tasks, overrides],
-  );
+  const { effectiveTasks, applyOverride, applyReorder, sensors, setActiveId, activeTask } =
+    useOptimisticTaskDnd(tasks);
   const bucketTasks = effectiveTasks.filter(
     (t) => t.status === "pending" && t.bucket === activeBucket,
   );
 
-  // Id of the task currently being dragged — drives the DragOverlay preview.
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const activeTask = activeId ? effectiveTasks.find((t) => t.id === activeId) : null;
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
-    useSensor(KeyboardSensor),
-  );
-
-  function handleDragStart(event: DragStartEvent) {
-    setActiveId(String(event.active.id));
+  async function reprioritize(taskId: string, important: boolean, urgent: boolean) {
+    applyOverride(taskId, { important, urgent });
+    try {
+      await setPriority(taskId, { important, urgent });
+    } catch (err) {
+      console.error("Failed to set priority:", err);
+    }
+    onMutate();
   }
 
   async function handleDragEnd(event: DragEndEvent) {
@@ -183,22 +159,36 @@ export function QuadrantLayout({
     const data = over.data.current;
     if (!data) return;
 
-    if (data.kind === "priority") {
-      const { important, urgent } = data as { important: boolean; urgent: boolean };
-      // Same-cell drop — no change, no network call.
-      if (task.important === important && task.urgent === urgent) return;
-      setOverrides((prev) => ({ ...prev, [taskId]: { ...prev[taskId], important, urgent } }));
+    if (data.kind === "reorder-card") {
+      const overId = (data as { taskId: string }).taskId;
+      if (overId === taskId) return;
+      const overTask = bucketTasks.find((t) => t.id === overId);
+      if (!overTask) return;
+      // Different cell → reclassify to that card's priority. Same cell → reorder.
+      if (task.important !== overTask.important || task.urgent !== overTask.urgent) {
+        await reprioritize(taskId, overTask.important, overTask.urgent);
+        return;
+      }
+      const ids = bucketTasks.map((t) => t.id);
+      const from = ids.indexOf(taskId);
+      const to = ids.indexOf(overId);
+      if (from < 0 || to < 0) return;
+      const newOrder = arrayMove(ids, from, to);
+      applyReorder(activeBucket, newOrder);
       try {
-        await setPriority(taskId, { important, urgent });
+        await reorderTasks(newOrder, activeBucket);
       } catch (err) {
-        console.error("Failed to set priority:", err);
+        console.error("Failed to reorder:", err);
       }
       onMutate();
+    } else if (data.kind === "priority") {
+      const { important, urgent } = data as { important: boolean; urgent: boolean };
+      if (task.important === important && task.urgent === urgent) return; // same cell — no-op
+      await reprioritize(taskId, important, urgent);
     } else if (data.kind === "bucket") {
       const { bucket } = data as { bucket: BucketType };
-      // Dropped on the current bucket's tab — no change.
-      if (task.bucket === bucket) return;
-      setOverrides((prev) => ({ ...prev, [taskId]: { ...prev[taskId], bucket } }));
+      if (task.bucket === bucket) return; // same bucket — no-op
+      applyOverride(taskId, { bucket });
       try {
         await updateTask(taskId, { bucket });
       } catch (err) {
@@ -211,8 +201,8 @@ export function QuadrantLayout({
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={pointerWithin}
-      onDragStart={handleDragStart}
+      collisionDetection={reorderAwareCollision}
+      onDragStart={(e) => setActiveId(String(e.active.id))}
       onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveId(null)}
     >

--- a/frontend/src/components/layouts/use-optimistic-task-dnd.ts
+++ b/frontend/src/components/layouts/use-optimistic-task-dnd.ts
@@ -2,8 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  closestCenter,
+  type CollisionDetection,
   KeyboardSensor,
   PointerSensor,
+  pointerWithin,
   TouchSensor,
   useSensor,
   useSensors,
@@ -11,30 +14,71 @@ import {
 import type { Task } from "@/lib/api-types";
 
 /**
+ * Collision detection that supports both reordering and reclassifying. If the
+ * pointer is over a card (a `kind: "reorder-card"` droppable), it resolves to
+ * the nearest card center so card-on-card reordering is precise. Otherwise it
+ * falls back to `pointerWithin`, so drops on group containers and bucket tabs
+ * still work.
+ */
+export const reorderAwareCollision: CollisionDetection = (args) => {
+  const pointer = pointerWithin(args);
+  const cardContainers = args.droppableContainers.filter(
+    (d) => d.data.current?.kind === "reorder-card",
+  );
+  const overCard = pointer.some((c) => cardContainers.some((d) => d.id === c.id));
+  if (overCard && cardContainers.length > 0) {
+    return closestCenter({ ...args, droppableContainers: cardContainers });
+  }
+  return pointer;
+};
+
+/**
  * Shared drag-and-drop plumbing for the task layouts (Grouped, Quadrant, Matrix).
  *
- * Holds an optimistic overlay so a drop lands instantly: `applyOverride` patches
- * a task locally, `effectiveTasks` reflects the patch, and the overlay clears
- * when the `tasks` reference changes — which only happens on a refetch (the
- * parent's `onMutate`/`refresh`), by which point the real data already reflects
- * the change, so there's no flicker. Also wires the standard sensor set and
- * tracks the actively-dragged task id for a DragOverlay preview.
+ * Optimistic overlay so a drop lands instantly:
+ * - `applyOverride` patches a task's fields locally (reclassify: domain/priority/bucket).
+ * - `applyReorder` sets a per-bucket optimistic order (within-group reorder).
+ * Both clear when the `tasks` reference changes — which only happens on a refetch
+ * (the parent's `onMutate`/`refresh`), by which point the real data already
+ * reflects the change, so there's no flicker.
  *
- * Each view supplies its own `onDragEnd` (the per-view reclassify logic) and
- * renders its own DragOverlay ghost from `activeTask`.
+ * Each view supplies its own `onDragEnd` and renders its own DragOverlay ghost.
  */
 export function useOptimisticTaskDnd(tasks: Task[]) {
   const [overrides, setOverrides] = useState<Record<string, Partial<Task>>>({});
-  useEffect(() => setOverrides({}), [tasks]);
+  const [orderOverride, setOrderOverride] = useState<{ bucket: string; ids: string[] } | null>(
+    null,
+  );
+  useEffect(() => {
+    setOverrides({});
+    setOrderOverride(null);
+  }, [tasks]);
 
   const applyOverride = useCallback((taskId: string, patch: Partial<Task>) => {
     setOverrides((prev) => ({ ...prev, [taskId]: { ...prev[taskId], ...patch } }));
   }, []);
 
-  const effectiveTasks = useMemo(
-    () => tasks.map((t) => (overrides[t.id] ? { ...t, ...overrides[t.id] } : t)),
-    [tasks, overrides],
-  );
+  const applyReorder = useCallback((bucket: string, ids: string[]) => {
+    setOrderOverride({ bucket, ids });
+  }, []);
+
+  const effectiveTasks = useMemo(() => {
+    let result = tasks.map((t) => (overrides[t.id] ? { ...t, ...overrides[t.id] } : t));
+    if (orderOverride) {
+      // Slot the reordered bucket tasks back into the positions the bucket's
+      // tasks occupied, leaving other buckets' tasks untouched.
+      const byId = new Map(result.map((t) => [t.id, t]));
+      const reordered = orderOverride.ids
+        .map((id) => byId.get(id))
+        .filter((t): t is Task => Boolean(t));
+      const idSet = new Set(orderOverride.ids);
+      let i = 0;
+      result = result.map((t) =>
+        t.bucket === orderOverride.bucket && idSet.has(t.id) ? reordered[i++] : t,
+      );
+    }
+    return result;
+  }, [tasks, overrides, orderOverride]);
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const activeTask = activeId ? (effectiveTasks.find((t) => t.id === activeId) ?? null) : null;
@@ -45,5 +89,5 @@ export function useOptimisticTaskDnd(tasks: Task[]) {
     useSensor(KeyboardSensor),
   );
 
-  return { effectiveTasks, applyOverride, sensors, activeId, setActiveId, activeTask };
+  return { effectiveTasks, applyOverride, applyReorder, sensors, activeId, setActiveId, activeTask };
 }


### PR DESCRIPTION
## What
Completes the shared-ordering vision: drag a card **onto another card in the same group** to reorder it. The new order persists (shared per-bucket `position` via `reorderTasks`) and shows in every view. Card-on-card in a *different* group, or drops on a group container / bucket tab, reclassify exactly as before.

**"Same group":** same domain (Grouped) / same important+urgent (Quadrant) / same domain+bucket (Matrix).

## How
- **`useOptimisticTaskDnd`**: adds `applyReorder(bucket, ids)` — an optimistic per-bucket order override (cleared on `[tasks]` like the field overrides, so no flicker) — and exports **`reorderAwareCollision`**: prefer card targets (`closestCenter` among `reorder-card` droppables) when the pointer is over a card, else `pointerWithin` for group containers + bucket tabs.
- **`DraggableTaskItem`**: now *also* a card-level `useDroppable` (`kind: "reorder-card"`) with an insertion-line indicator on `isOver` (drop-position feedback without `SortableContext`).
- **Grouped / Quadrant / Matrix `onDragEnd`**: a reorder branch (`over.kind === "reorder-card"` + same group) computes the new bucket order with `arrayMove` and calls `reorderTasks`. Different-group card drops fall back to reclassify.
- **Refactor:** Quadrant now uses the shared hook (removes its inline overlay duplication — the deferred cleanup).

## Verification (Playwright + DB ground truth)
| Check | Result |
|-------|--------|
| Quadrant reorder | `reorder 200` → order changed ✓ |
| Quadrant reclassify (regression) | `priority 200` → still works ✓ |
| Grouped reorder | order changed ✓ |
| Matrix reorder | order changed ✓ |

Plus `tsc --noEmit`, `npm run lint`, `npm run build` clean.

Closes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)