### PR TITLE
ci: run on push to main to unblock Railway deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
-# PR-only. The required `check` is produced by the PR run, so re-running on the
-# squash-merge commit (push) was pure duplication. Railway auto-deploys from git
-# push independently of Actions, so deploys are unaffected. See
-# ~/.claude/knowledge-base/github-actions-cost-control.md
+# Runs on PRs AND on push to main. The push run is required: Railway is gated on
+# the CI status check before it deploys a main commit, so without a push-triggered
+# `check` on the squash-merge commit, Railway waits forever and never deploys.
+# (PR-only — the prior setup — silently froze prod at #183 from 2026-05-26 to
+# 2026-06-04. See ~/.claude/knowledge-base/github-actions-cost-control.md)
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Problem
Production has been frozen at commit `005e279` (#183, 2026-05-26) — every merge since (layout switcher, all drag-and-drop work) built and merged but never deployed.

**Root cause:** Railway waits for the CI status check before deploying a `main` commit. #183 made CI `pull_request`-only, so squash-merge commits to `main` produce no check → Railway waits forever → never deploys. The #183 comment claiming "Railway auto-deploys independently of Actions" was incorrect.

## Fix
Restore `push: branches: [main]` so each merge commit gets a `check`, satisfying Railway's gate. This self-bootstraps: merging this PR is a push that (with the updated trigger) runs CI on the merge commit → Railway deploys current `main`, shipping the entire backlog at once. Cost: one CI run per merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)