### PR TITLE
feat(onboarding): launch-readiness polish for cold-start + feedback

### DIFF
--- a/frontend/src/app/(app)/bucket/[b]/page.tsx
+++ b/frontend/src/app/(app)/bucket/[b]/page.tsx
@@ -259,7 +259,11 @@ export default function BucketPage() {
                   Nothing here yet. Tasks untouched for 30 days will return to the soil.
                 </p>
               ) : (
-                compostTasks.map((task) => (
+                <>
+                <p className="text-xs text-text-muted pt-1 pb-3 px-3">
+                  Composting clears out tasks you haven&apos;t touched in 30 days. Restore the ones you still want; let the rest go.
+                </p>
+                {compostTasks.map((task) => (
                   <div key={task.id} className="py-2 px-3">
                     {confirmingId === task.id ? (
                       <div className="flex items-center justify-between text-sm">
@@ -313,7 +317,8 @@ export default function BucketPage() {
                       </div>
                     )}
                   </div>
-                ))
+                ))}
+                </>
               )}
             </div>
           </details>

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -11,6 +11,7 @@ import { useTheme } from "@/components/theme-provider";
 import { WinddownModal } from "@/components/winddown-modal";
 import { TriageReminderBanner } from "@/components/triage-reminder-banner";
 import { DomainNav } from "@/components/domain-nav";
+import { FeedbackWidget } from "@/components/feedback-widget";
 
 type NavIconName = "review" | "today" | "soon" | "later" | "someday" | "done" | "settings";
 
@@ -418,6 +419,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       {showWinddownModal && (
         <WinddownModal onComplete={() => { setShowWinddownModal(false); setRefreshKey((k) => k + 1); }} />
       )}
+
+      {/* Persistent feedback affordance — present on every page incl. onboarding */}
+      <FeedbackWidget />
     </div>
   );
 }

--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -253,7 +253,9 @@ export default function OnboardingPage() {
           <div className="text-center space-y-2">
             <h1 className="text-2xl font-semibold text-text-primary">What&apos;s on your mind?</h1>
             <p className="text-sm text-text-secondary">
-              Add a few things you need to deal with. Think small &mdash; what could you actually finish today?
+              Add a few things you&apos;re juggling. Each morning, Tend walks you
+              through them one at a time so you can pick what matters today.
+              Think small.
             </p>
             {selectedDomains.length > 0 && (
               <p className="text-xs text-text-muted">Tap ⊕ to assign a life area</p>

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -45,9 +45,16 @@ export default function SignupPage() {
       <div className="w-full max-w-sm space-y-8">
         <div className="text-center">
           <h1 className="text-4xl font-bold text-text-primary tracking-tight">Tend</h1>
-          <p className="mt-2 text-sm text-text-secondary">
-            Create your account
+          <p className="mt-3 text-sm text-text-secondary leading-relaxed">
+            A quiet todo app built around a two-minute morning triage. Decide
+            what matters today, and nothing else sneaks in.
           </p>
+          <Link
+            href="/"
+            className="mt-2 inline-block text-xs text-text-muted hover:text-text-secondary transition-colors"
+          >
+            What&apos;s this?
+          </Link>
         </div>
 
         <div className="space-y-4">

--- a/frontend/src/components/feedback-widget.tsx
+++ b/frontend/src/components/feedback-widget.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { sendFeedback } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type Status = "idle" | "sending" | "sent" | "error";
+
+/**
+ * Persistent feedback affordance shown across every authenticated page,
+ * including the onboarding flow (where early confusion is most likely).
+ * Reuses the same `sendFeedback` API as the Settings feedback form; the
+ * backend emails it straight to Brandon. A floating trigger opens a modal so
+ * a stuck user never has to hunt through Settings to reach it.
+ */
+export function FeedbackWidget() {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+
+  async function handleSend() {
+    if (!text.trim() || status === "sending") return;
+    setStatus("sending");
+    try {
+      await sendFeedback(text.trim());
+      setText("");
+      setStatus("sent");
+    } catch (err) {
+      console.error("Failed to send feedback:", err);
+      setStatus("error");
+    }
+  }
+
+  function close() {
+    setOpen(false);
+    setText("");
+    setStatus("idle");
+  }
+
+  return (
+    <>
+      {/* Floating trigger — sits above the mobile tab bar, below modals */}
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Send feedback"
+        className="fixed bottom-20 right-4 md:bottom-6 md:right-6 z-30 flex items-center gap-2 rounded-full border border-border bg-bg-card px-4 min-h-[44px] text-[13px] text-text-secondary shadow-sm hover:bg-bg-hover transition-colors"
+      >
+        <svg
+          className="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.75}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        <span className="hidden sm:inline">Feedback</span>
+      </button>
+
+      {open && (
+        <div
+          onClick={close}
+          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 px-4 py-6"
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-sm rounded-2xl border border-border bg-bg-card p-5 space-y-3 shadow-xl"
+          >
+            <div className="space-y-1">
+              <h2 className="text-sm font-medium text-text-primary">
+                Send feedback
+              </h2>
+              <p className="text-xs text-text-muted leading-relaxed">
+                Tend is early and built by one person. Bugs, confusion, or
+                wishes: it all goes straight to Brandon.
+              </p>
+            </div>
+
+            {status === "sent" ? (
+              <div className="space-y-3">
+                <p className="text-sm text-accent-green">
+                  Sent to Brandon. Thank you.
+                </p>
+                <button
+                  onClick={close}
+                  className="text-sm text-text-secondary border border-border rounded-lg px-4 min-h-[44px] hover:bg-bg-hover transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <>
+                <textarea
+                  value={text}
+                  onChange={(e) => {
+                    setText(e.target.value);
+                    if (status !== "idle") setStatus("idle");
+                  }}
+                  placeholder="What's on your mind?"
+                  maxLength={2000}
+                  rows={4}
+                  autoFocus
+                  className="w-full bg-bg-input border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none resize-none"
+                />
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    onClick={close}
+                    className="text-sm text-text-muted px-3 min-h-[44px] hover:text-text-secondary transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={handleSend}
+                    disabled={!text.trim() || status === "sending"}
+                    className={cn(
+                      "text-sm rounded-lg px-4 min-h-[44px] transition-colors",
+                      status === "error"
+                        ? "text-accent-red border border-accent-red/30"
+                        : "text-text-secondary border border-border hover:bg-bg-hover disabled:opacity-30",
+                    )}
+                  >
+                    {status === "sending" && "Sending..."}
+                    {status === "error" && "Try again"}
+                    {(status === "idle") && "Send feedback"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Onboarding-audit fixes ahead of distributing Tend for feedback (not revenue). The audit found Tend already wins where most pre-launch apps fail (a landing page that teaches the concept before asking for anything); the gaps were two and cheap: deep-link arrivals hit a contextless signup form, and the feedback path was buried in Settings.

## Changes

1. **Signup value-prop** (`(auth)/signup/page.tsx`) — adds a one-line explainer of what Tend is, plus a "What's this?" link back to the landing page. A Reddit/HN deep-link arrival who never saw the landing page now knows what they're signing up for instead of bouncing on a bare email/password form.

2. **Persistent feedback widget** (new `components/feedback-widget.tsx`, mounted in `(app)/layout.tsx`) — a low-key floating "Feedback" button on every authenticated page **including onboarding**, opening a modal that reuses the existing `sendFeedback` API (emails straight to Brandon via Resend). The feedback form already existed; this just surfaces it so a stuck new user doesn't have to find Settings.

3. **Onboarding reorder** (`(app)/onboarding/page.tsx`) — step 3 now explains the morning triage ritual *before* asking for tasks, instead of only on the post-onboarding screen.

4. **Compost gloss** (`(app)/bucket/[b]/page.tsx`) — a one-line definition of "composting" at the point composted tasks actually appear on Someday.

## Deliberately not done

- **No seeded fake starter task.** The generic onboarding playbook says "seed the empty state," but step 3 already collects the user's real tasks and "blank is the point" is Tend's brand. A fake task would fight the product's soul.
- **MIT needed no fix.** The audit flagged it as jargon, but `mit-selection.tsx` already spells it out fully ("What's your most important task today?") and never shows the acronym.
- **Signup/login-stage feedback** (pre-auth) is out of scope: `sendFeedback` requires a session, so it would need a separate unauthenticated route (same pattern as password reset). Deferred.

## Verification

Ran the app locally (Next.js + FastAPI + Postgres) and drove it in a browser:
- Signup value-prop + "What's this?" link render.
- Feedback widget present on onboarding steps 1/2/3 and authenticated app pages; modal opens with correct copy and disabled-until-typed Send.
- Step 3 reordered copy renders before the task form.
- Compost gloss renders above a composted task (verified by injecting an archived Someday task).

`tsc --noEmit` and `eslint` pass clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)