### PR TITLE
Harden: disable interactive API docs in production

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,8 +11,15 @@ class Settings(BaseSettings):
     stripe_secret_key: str = ""
     stripe_webhook_secret: str = ""
     stripe_price_id: str = ""
+    # Set by Railway automatically (e.g. "production"). Used to hide the
+    # interactive API docs once the backend is reachable from the internet.
+    railway_environment: str = ""
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+
+    @property
+    def is_production(self) -> bool:
+        return self.railway_environment == "production"
 
     @model_validator(mode="after")
     def fix_database_url(self) -> "Settings":

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,17 @@ from app.core.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Tend", version="0.2.0")
+# Hide the interactive docs + OpenAPI schema in production. The backend is now
+# reachable from the internet (a desktop client calls it directly), and there is
+# no reason to advertise the full API surface publicly. Data routes are already
+# JWT-gated; this just closes the schema/docs endpoints.
+app = FastAPI(
+    title="Tend",
+    version="0.2.0",
+    docs_url=None if settings.is_production else "/docs",
+    redoc_url=None if settings.is_production else "/redoc",
+    openapi_url=None if settings.is_production else "/openapi.json",
+)
 app.state.limiter = limiter
 
 # Routers


### PR DESCRIPTION
## Why
The backend just got a public Railway domain (`tend-backend-production-4db2.up.railway.app`) so a desktop client (Plot, the time-block conductor) can call it directly with a self-minted proxy JWT. Previously it was Railway-private.

Now that it's internet-reachable, there's no reason to advertise the full API surface. This hides `/docs`, `/redoc`, and `/openapi.json` in production.

## Scope / safety
- Data routes remain JWT-gated; `/users/*` sign-in routes remain rate-limited (5-10/min). This change only closes the schema/docs endpoints.
- Toggled by `RAILWAY_ENVIRONMENT` (auto-set by Railway). Dev keeps its docs.
- 178 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)