### PR TITLE
Tend × Plot integration: PATs, one-Enter capture, keyboard triage, placements, size, PWA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,19 @@ JWT-based tokens, no database migration. Token encodes `{sub: user_id, purpose: 
 ### Unauthenticated API Routes
 The main `[...proxy]` catch-all requires a NextAuth session. Endpoints that must work without auth (password reset, etc.) need their own routes in `frontend/src/app/api/` that forward to the backend directly. Same pattern as `auth.ts` calling `/users` and `/users/verify`.
 
+### Personal Access Tokens (PATs) — scoping by opt-in dependency
+External clients (Plot, Raycast, iOS Shortcuts) authenticate with a `tend_pat_...` token instead of the 60s proxy JWT. Design:
+- `api_tokens` table stores only a **SHA-256 hash** of the raw token (fast, unsalted — auth looks a token up by hash without knowing the user). The raw value is shown **once** at creation.
+- `core/security.py` has two dependencies: `get_current_user_id` (proxy-JWT only, the default for every route) and `get_user_id_allow_pat` (accepts a PAT **or** the proxy JWT).
+- **Scoping is expressed by which routes use `get_user_id_allow_pat`** — there is no per-path allowlist. A PAT works only on the endpoints that opted in (currently `GET/POST /tasks`, `POST /tasks/{id}/complete`, `POST /tasks/{id}/mit`, `GET /triage`, `POST /tasks/{id}/placements`). To expose a new endpoint to PATs, switch its dependency; to keep it internal, leave `get_current_user_id`.
+- **Test gotcha:** `conftest.py` must override *both* auth dependencies. To test real PAT auth/scoping, pop the overrides in a fixture (see `TestPatScoping` in `test_api_tokens.py`).
+
+### Task Placements — Tend records, never schedules
+`task_placements` stores the fact that Plot placed a task into a time block (`{task_id, date, block_start, block_type, calendar_event_id}`), upserting on `(task_id, date)`. This does **not** make Tend a calendar — it records a reported fact the way `reschedule_count` does. `POST /tasks/{id}/placements` is PAT-scoped. `TaskResponse.placement` carries **today's** placement (passed explicitly to `_to_response`, never via `task.placements` — that relationship is `lazy="raise"`; use `placement_service.get_placements_for_date` to build a `{task_id: placement}` map and pass it in). Wind-down uses placement to distinguish "had a block, didn't finish" (planning-honesty) from "never got a block" (triage-honesty).
+
+### Status transitions: complete→pending is a "reopen"
+`update_task` allows `pending↔archived` **and** `complete→pending` (clears `completed_at`). The reopen exists so keyboard-triage undo can revert a "Done". `complete→archived` is still invalid.
+
 ## Project Structure
 
 ```
@@ -322,6 +335,15 @@ Floating popovers anchored to a row inside `SortableTaskItem` (or any `transform
 2. **Use a vertical menu (`flex flex-col` + fixed width like `w-[140px]`)**, not a horizontal pill row. Horizontal rows scale with item count and overflow narrow viewports / sidebars / quadrant cards; vertical menus never do.
 
 `domain-picker.tsx` follows this pattern. Mirror it for any new task-row popover.
+
+### Capture token grammar
+`lib/parse-capture.ts` is a **pure** function that pulls inline tokens out of a task string: `#domain` (prefix-matched against the user's domains, first match wins), `!` (important), `!!` (important+urgent), `u!`/`!u` (urgent), `>today|soon|later|someday` (bucket), `~s|~m|~l` (size). Recognized tokens are stripped from the text; unrecognized `#tags` are left verbatim. `task-input.tsx` submits on a single Enter (refocuses for rapid-fire; never disables the input) and opens the domain/priority picker on **Tab**, not Enter. The `/capture` PWA share-target page reuses the same parser.
+
+### Keyboard-driven triage + undo
+`triage-card.tsx` binds a window `keydown` listener (ignored while a text input/textarea is focused or in rewrite/note edit): `t/s/l/o` bucket, `d` done, `x` let go, `n` note, `r` rewrite, `1/2/3` size, `z` undo. **"Let go" is a reversible soft-archive** (`updateTask status=archived`), not the hard-delete `kill` triage action — so undo can restore it (archived tasks live on the Someday page). The undo stack lives in `triage-flow.tsx`: each action records `{index, taskId, action, prevBucket}`; `z` moves the index back and issues a compensating `updateTask` (restore bucket, or `status=pending` to un-archive / reopen). Advancement is **index-based**, not driven by the server's `remaining`, so synthesized results (from the archive path) work too.
+
+### PWA share target
+`app/manifest.ts` (Next metadata route) declares a `share_target` pointing at `/capture`; `public/sw.js` is a deliberately no-op service worker (installability only, **no** offline caching/sync); `components/pwa-register.tsx` registers it from the root layout. `share_target` isn't in Next's `Manifest` type — extend it locally with a cast.
 
 ## Merging PRs
 

--- a/backend/alembic/versions/2026_07_06_0001-d4e5f6a7b8c9_add_size_to_tasks.py
+++ b/backend/alembic/versions/2026_07_06_0001-d4e5f6a7b8c9_add_size_to_tasks.py
@@ -1,0 +1,30 @@
+"""Add size (S/M/L) to tasks
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-06 00:01:00.000000
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, Sequence[str], None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable TEXT (StrEnum-as-TEXT convention); CHECK enforces valid values.
+    op.add_column("tasks", sa.Column("size", sa.String(), nullable=True))
+    op.create_check_constraint(
+        "ck_tasks_size", "tasks", "size IS NULL OR size IN ('s', 'm', 'l')"
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_tasks_size", "tasks", type_="check")
+    op.drop_column("tasks", "size")

--- a/backend/alembic/versions/2026_07_06_0002-e5f6a7b8c9d0_create_api_tokens.py
+++ b/backend/alembic/versions/2026_07_06_0002-e5f6a7b8c9d0_create_api_tokens.py
@@ -1,0 +1,39 @@
+"""Create api_tokens (personal access tokens)
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-06 00:02:00.000000
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_tokens",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_api_tokens_user_id", "api_tokens", ["user_id"])
+    op.create_index("ix_api_tokens_token_hash", "api_tokens", ["token_hash"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_api_tokens_token_hash", table_name="api_tokens")
+    op.drop_index("ix_api_tokens_user_id", table_name="api_tokens")
+    op.drop_table("api_tokens")

--- a/backend/alembic/versions/2026_07_06_0003-f6a7b8c9d0e1_create_task_placements.py
+++ b/backend/alembic/versions/2026_07_06_0003-f6a7b8c9d0e1_create_task_placements.py
@@ -1,0 +1,46 @@
+"""Create task_placements (Plot time-block write-back)
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-07-06 00:03:00.000000
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "task_placements",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("task_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("block_start", sa.DateTime(), nullable=True),
+        sa.Column("block_type", sa.String(), nullable=True),
+        sa.Column("calendar_event_id", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("task_id", "date", name="uq_placement_task_date"),
+    )
+    op.create_index("ix_task_placements_task_id", "task_placements", ["task_id"])
+    op.create_index("ix_task_placements_user_id", "task_placements", ["user_id"])
+    op.create_index("ix_task_placements_date", "task_placements", ["date"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_placements_date", table_name="task_placements")
+    op.drop_index("ix_task_placements_user_id", table_name="task_placements")
+    op.drop_index("ix_task_placements_task_id", table_name="task_placements")
+    op.drop_table("task_placements")

--- a/backend/app/api/api_tokens.py
+++ b/backend/app/api/api_tokens.py
@@ -1,0 +1,57 @@
+import uuid
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from app.core.deps import get_db
+from app.core.security import get_current_user_id
+from app.schemas.api_token_schemas import (
+    ApiTokenCreate,
+    ApiTokenCreated,
+    ApiTokenResponse,
+)
+from app.services import api_token_service
+
+router = APIRouter(prefix="/api-tokens", tags=["api-tokens"])
+
+
+def _to_response(token) -> ApiTokenResponse:
+    return ApiTokenResponse(
+        id=token.id,
+        name=token.name,
+        created_at=token.created_at,
+        last_used_at=token.last_used_at,
+    )
+
+
+@router.get("", response_model=list[ApiTokenResponse])
+def list_api_tokens(
+    db: Session = Depends(get_db),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+):
+    return [_to_response(t) for t in api_token_service.list_tokens(db, user_id)]
+
+
+@router.post("", response_model=ApiTokenCreated, status_code=201)
+def create_api_token(
+    body: ApiTokenCreate,
+    db: Session = Depends(get_db),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+):
+    token, raw = api_token_service.create_token(db, user_id, body.name)
+    return ApiTokenCreated(
+        id=token.id,
+        name=token.name,
+        created_at=token.created_at,
+        last_used_at=token.last_used_at,
+        token=raw,
+    )
+
+
+@router.delete("/{token_id}", status_code=204)
+def revoke_api_token(
+    token_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+):
+    api_token_service.revoke_token(db, user_id, token_id)

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -5,10 +5,12 @@ from sqlmodel import Session
 
 from app.core.deps import get_db
 from app.core.errors import AppError
-from app.core.security import get_current_user_id
+from app.core.security import get_current_user_id, get_user_id_allow_pat
 from app.models.enums import BucketType, TaskStatus
 from app.schemas.task_schemas import (
     DomainBrief,
+    PlacementBrief,
+    PlacementCreate,
     PriorityUpdate,
     ReorderRequest,
     SubTaskResponse,
@@ -16,12 +18,12 @@ from app.schemas.task_schemas import (
     TaskResponse,
     TaskUpdate,
 )
-from app.services import mit_service, task_service
+from app.services import mit_service, placement_service, task_service
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
-def _to_response(task, mit_task_id: uuid.UUID | None = None) -> TaskResponse:
+def _to_response(task, mit_task_id: uuid.UUID | None = None, placement=None) -> TaskResponse:
     return TaskResponse(
         id=task.id,
         text=task.text,
@@ -44,6 +46,14 @@ def _to_response(task, mit_task_id: uuid.UUID | None = None) -> TaskResponse:
         is_mit=mit_task_id is not None and task.id == mit_task_id,
         important=task.important,
         urgent=task.urgent,
+        size=task.size,
+        placement=PlacementBrief(
+            block_start=placement.block_start,
+            block_type=placement.block_type,
+            calendar_event_id=placement.calendar_event_id,
+        )
+        if placement is not None
+        else None,
     )
 
 
@@ -53,11 +63,14 @@ def list_tasks(
     status: TaskStatus | None = None,
     domain_id: uuid.UUID | None = None,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
+    from datetime import date
+
     tasks = task_service.get_tasks(db, user_id, bucket=bucket, status=status, domain_id=domain_id)
     mit_id = mit_service.get_today_mit(db, user_id)
-    return [_to_response(t, mit_task_id=mit_id) for t in tasks]
+    placements = placement_service.get_placements_for_date(db, user_id, date.today())
+    return [_to_response(t, mit_task_id=mit_id, placement=placements.get(t.id)) for t in tasks]
 
 
 @router.get("/{task_id}", response_model=TaskResponse)
@@ -74,7 +87,7 @@ def get_task(
 def create_task(
     body: TaskCreate,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     # Only honor skip_triage_stamp during onboarding (prevents abuse after onboarding)
     skip_stamp = False
@@ -96,6 +109,7 @@ def create_task(
         skip_triage_stamp=skip_stamp,
         important=body.important,
         urgent=body.urgent,
+        size=body.size,
     )
     # Reload with relationships for response
     task = task_service.get_task(db, user_id, task.id)
@@ -134,6 +148,8 @@ def update_task(
         kwargs["important"] = body.important
     if body.urgent is not None:
         kwargs["urgent"] = body.urgent
+    if body.size is not None:
+        kwargs["size"] = body.size
     task = task_service.update_task(db, user_id, task_id, **kwargs)
     return _to_response(task)
 
@@ -158,7 +174,7 @@ def set_priority(
 def complete_task(
     task_id: uuid.UUID,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     task = task_service.complete_task(db, user_id, task_id)
     task = task_service.get_task(db, user_id, task.id)
@@ -178,7 +194,7 @@ def delete_task(
 def set_mit(
     task_id: uuid.UUID,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     task = task_service.get_task(db, user_id, task_id)
     if task.status != TaskStatus.pending:
@@ -195,3 +211,28 @@ def set_mit(
         )
     mit_service.set_mit(db, user_id, task_id)
     return _to_response(task, mit_task_id=task_id)
+
+
+@router.post("/{task_id}/placements", response_model=TaskResponse, status_code=201)
+def create_placement(
+    task_id: uuid.UUID,
+    body: PlacementCreate,
+    db: Session = Depends(get_db),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
+):
+    """Record that Plot placed a task into a time block (PAT-scoped).
+
+    Tend never schedules — this only stores the fact Plot reports. Upserts on
+    (task, date), so re-placing the same task on the same day is idempotent.
+    """
+    placement = placement_service.record_placement(
+        db,
+        user_id,
+        task_id,
+        placement_date=body.placement_date,
+        block_start=body.block_start,
+        block_type=body.block_type,
+        calendar_event_id=body.calendar_event_id,
+    )
+    task = task_service.get_task(db, user_id, task_id)
+    return _to_response(task, placement=placement)

--- a/backend/app/api/triage.py
+++ b/backend/app/api/triage.py
@@ -7,7 +7,7 @@ from sqlmodel import Session, select
 from app.api.tasks import _to_response
 from app.core.deps import get_db
 from app.core.errors import AppError
-from app.core.security import get_current_user_id
+from app.core.security import get_current_user_id, get_user_id_allow_pat
 from app.models.enums import BucketType, TaskStatus
 from app.models.task import Task
 from app.models.user import User
@@ -23,6 +23,7 @@ from app.services import (
     briefing_service,
     composter_service,
     mit_service,
+    placement_service,
     stats_service,
     triage_service,
 )
@@ -35,7 +36,7 @@ router = APIRouter(prefix="/triage", tags=["triage"])
 @router.get("", response_model=TriageQueueResponse)
 def get_triage_queue(
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     # Compost stale tasks before building the triage queue.
     # Savepoint ensures a composter failure rolls back cleanly
@@ -121,6 +122,8 @@ def get_winddown(
     db: Session = Depends(get_db),
     user_id: uuid.UUID = Depends(get_current_user_id),
 ):
+    from datetime import date
+
     tasks = triage_service.get_winddown_tasks(db, user_id)
     mit_task_id = mit_service.get_today_mit(db, user_id)
     mit_completed: bool | None = None
@@ -128,7 +131,11 @@ def get_winddown(
         mit_task = db.get(Task, mit_task_id)
         if mit_task is not None:
             mit_completed = mit_task.status == TaskStatus.complete
+    # Enrich with today's placements so the frontend can distinguish
+    # "had a block and didn't finish" (planning-honesty) from
+    # "never got a block" (triage-honesty).
+    placements = placement_service.get_placements_for_date(db, user_id, date.today())
     return WinddownResponse(
-        tasks=[_to_response(t) for t in tasks],
+        tasks=[_to_response(t, placement=placements.get(t.id)) for t in tasks],
         mit_completed=mit_completed,
     )

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,12 +1,29 @@
 import uuid
 
-from fastapi import Header
+from fastapi import Depends, Header
 from jose import JWTError, jwt
+from sqlmodel import Session
 
 from app.core.config import settings
+from app.core.deps import get_db
 from app.core.errors import AppError
 
 ALGORITHM = "HS256"
+
+
+def _user_id_from_jwt(token: str) -> uuid.UUID | None:
+    """Decode a proxy JWT to a user_id, or None if it isn't a valid one."""
+    try:
+        payload = jwt.decode(token, settings.internal_jwt_secret, algorithms=[ALGORITHM])
+    except JWTError:
+        return None
+    sub = payload.get("sub")
+    if sub is None:
+        return None
+    try:
+        return uuid.UUID(sub)
+    except ValueError:
+        return None
 
 
 def get_current_user_id(
@@ -52,3 +69,48 @@ def get_current_user_id(
             message="Invalid user ID in token",
             status_code=401,
         )
+
+
+def get_user_id_allow_pat(
+    authorization: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> uuid.UUID:
+    """Like ``get_current_user_id`` but also accepts a personal access token.
+
+    Apply this dependency ONLY to the endpoints external clients (Plot, capture
+    tools) are allowed to reach. The proxy JWT continues to work everywhere,
+    including these routes; a ``tend_pat_...`` token works ONLY on routes that
+    opt in by using this dependency. That is the whole scoping mechanism — no
+    per-path allowlist needed.
+    """
+    if authorization is None or not authorization.startswith("Bearer "):
+        raise AppError(
+            code="unauthorized",
+            message="Missing or invalid authorization header",
+            status_code=401,
+        )
+
+    token = authorization.removeprefix("Bearer ").strip()
+
+    # Personal access token path.
+    from app.services import api_token_service
+
+    if token.startswith(api_token_service.TOKEN_PREFIX):
+        user_id = api_token_service.authenticate(db, token)
+        if user_id is None:
+            raise AppError(
+                code="unauthorized",
+                message="Invalid or revoked access token",
+                status_code=401,
+            )
+        return user_id
+
+    # Otherwise fall back to the short-lived proxy JWT.
+    user_id = _user_id_from_jwt(token)
+    if user_id is None:
+        raise AppError(
+            code="unauthorized",
+            message="Invalid or expired token",
+            status_code=401,
+        )
+    return user_id

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import text
 
-from app.api import account, billing, domains, state, tasks, triage
+from app.api import account, api_tokens, billing, domains, state, tasks, triage
 from app.core.config import settings
 from app.core.deps import engine
 from app.core.errors import AppError, app_error_handler
@@ -24,6 +24,7 @@ app.include_router(domains.router)
 app.include_router(account.router)
 app.include_router(billing.router)
 app.include_router(state.router)
+app.include_router(api_tokens.router)
 
 # Error handlers
 app.add_exception_handler(AppError, app_error_handler)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,15 +1,20 @@
+from app.models.api_token import ApiToken
 from app.models.daily_stat import DailyStat
 from app.models.domain import Domain
-from app.models.enums import AuthProvider, BucketType, TaskStatus
+from app.models.enums import AuthProvider, BucketType, SizeType, TaskStatus
 from app.models.task import Task
+from app.models.task_placement import TaskPlacement
 from app.models.user import User
 
 __all__ = [
     "User",
     "Task",
+    "TaskPlacement",
+    "ApiToken",
     "Domain",
     "DailyStat",
     "BucketType",
     "TaskStatus",
+    "SizeType",
     "AuthProvider",
 ]

--- a/backend/app/models/api_token.py
+++ b/backend/app/models/api_token.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class ApiToken(SQLModel, table=True):
+    """A personal access token a user issues for external clients (Plot, Raycast,
+    iOS Shortcuts, etc.).
+
+    Only the SHA-256 hash of the raw token is stored — the raw ``tend_pat_...``
+    value is shown once at creation and never persisted. Lookup at auth time is
+    by hash, so it must be a fast (non-salted) digest, not bcrypt.
+    """
+
+    __tablename__ = "api_tokens"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(foreign_key="users.id", ondelete="CASCADE", index=True)
+    token_hash: str = Field(index=True, unique=True)
+    name: str = Field(max_length=100)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    last_used_at: datetime | None = Field(default=None)

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -31,3 +31,15 @@ class LayoutType(StrEnum):
     grouped = "grouped"
     quadrant = "quadrant"
     matrix = "matrix"
+
+
+class SizeType(StrEnum):
+    """Coarse task size, set as a triage-time judgment (not a schedule).
+
+    S = under 30 min, M = about an hour, L = half a day. Consumed by Plot to
+    reason about block capacity; always optional in Tend.
+    """
+
+    small = "s"
+    medium = "m"
+    large = "l"

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -5,7 +5,7 @@ from typing import Optional
 from sqlalchemy import Column, Index, String
 from sqlmodel import Field, Relationship, SQLModel
 
-from app.models.enums import BucketType, TaskStatus
+from app.models.enums import BucketType, SizeType, TaskStatus
 
 
 class Task(SQLModel, table=True):
@@ -25,6 +25,8 @@ class Task(SQLModel, table=True):
     triaged_at: date | None = Field(default=None)
     important: bool = Field(default=False, nullable=False)
     urgent: bool = Field(default=False, nullable=False)
+    # Coarse size (S/M/L), optional. A triage-time judgment consumed by Plot.
+    size: SizeType | None = Field(default=None, sa_column=Column(String, nullable=True))
 
     # Parent task (one level of sub-tasks)
     parent_id: uuid.UUID | None = Field(
@@ -58,6 +60,11 @@ class Task(SQLModel, table=True):
     )
     children: list["Task"] = Relationship(
         back_populates="parent",
+        cascade_delete=True,
+        sa_relationship_kwargs={"lazy": "raise", "passive_deletes": True},
+    )
+    placements: list["TaskPlacement"] = Relationship(  # noqa: F821
+        back_populates="task",
         cascade_delete=True,
         sa_relationship_kwargs={"lazy": "raise", "passive_deletes": True},
     )

--- a/backend/app/models/task_placement.py
+++ b/backend/app/models/task_placement.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import date as date_type
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, String, UniqueConstraint
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class TaskPlacement(SQLModel, table=True):
+    """A record that a task was placed into a time block by Plot.
+
+    Tend never schedules — it only records the fact Plot reports (the same way it
+    records ``reschedule_count``). One placement per (task, date): re-placing on
+    the same day upserts. ``calendar_event_id`` is the Google Calendar event Plot
+    created, kept so Plot can reconcile.
+    """
+
+    __tablename__ = "task_placements"
+    __table_args__ = (UniqueConstraint("task_id", "date", name="uq_placement_task_date"),)
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    task_id: uuid.UUID = Field(foreign_key="tasks.id", ondelete="CASCADE", index=True)
+    user_id: uuid.UUID = Field(foreign_key="users.id", ondelete="CASCADE", index=True)
+    date: date_type = Field(index=True)
+    block_start: datetime | None = Field(default=None)
+    block_type: str | None = Field(default=None, sa_column=Column(String, nullable=True))
+    calendar_event_id: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    task: Optional["Task"] = Relationship(  # noqa: F821
+        back_populates="placements",
+        sa_relationship_kwargs={"lazy": "raise"},
+    )

--- a/backend/app/schemas/api_token_schemas.py
+++ b/backend/app/schemas/api_token_schemas.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ApiTokenCreate(BaseModel):
+    name: str
+
+
+class ApiTokenResponse(BaseModel):
+    """Metadata only — never carries the raw token."""
+
+    id: uuid.UUID
+    name: str
+    created_at: datetime
+    last_used_at: datetime | None
+
+
+class ApiTokenCreated(ApiTokenResponse):
+    """Returned once, at creation, with the raw token to copy."""
+
+    token: str

--- a/backend/app/schemas/task_schemas.py
+++ b/backend/app/schemas/task_schemas.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import date, datetime
 
-from pydantic import BaseModel, computed_field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
-from app.models.enums import BucketType, TaskStatus
+from app.models.enums import BucketType, SizeType, TaskStatus
 
 
 class PriorityUpdate(BaseModel):
@@ -20,6 +20,7 @@ class TaskCreate(BaseModel):
     skip_triage_stamp: bool = False
     important: bool = False
     urgent: bool = False
+    size: SizeType | None = None
 
 
 class TaskUpdate(BaseModel):
@@ -30,6 +31,7 @@ class TaskUpdate(BaseModel):
     notes: str | None = None
     important: bool | None = None
     urgent: bool | None = None
+    size: SizeType | None = None
 
 
 class ReorderRequest(BaseModel):
@@ -46,6 +48,21 @@ class ReorderRequest(BaseModel):
         return v
 
 
+class PlacementCreate(BaseModel):
+    """Plot reports that a task was placed into a time block.
+
+    The JSON field is ``date``; the attribute is ``placement_date`` to avoid
+    shadowing the ``date`` type annotation.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    placement_date: date = Field(alias="date")
+    block_start: datetime | None = None
+    block_type: str | None = None
+    calendar_event_id: str | None = None
+
+
 class DomainBrief(BaseModel):
     id: uuid.UUID
     name: str
@@ -57,6 +74,14 @@ class SubTaskResponse(BaseModel):
     text: str
     status: TaskStatus
     completed_at: datetime | None
+
+
+class PlacementBrief(BaseModel):
+    """Today's time-block placement for a task, as reported by Plot."""
+
+    block_start: datetime | None
+    block_type: str | None
+    calendar_event_id: str | None
 
 
 class TaskResponse(BaseModel):
@@ -76,6 +101,8 @@ class TaskResponse(BaseModel):
     is_mit: bool = False
     important: bool = False
     urgent: bool = False
+    size: SizeType | None = None
+    placement: PlacementBrief | None = None
 
     @computed_field
     @property

--- a/backend/app/services/api_token_service.py
+++ b/backend/app/services/api_token_service.py
@@ -1,0 +1,80 @@
+import hashlib
+import secrets
+import uuid
+from datetime import datetime
+
+from sqlmodel import Session, select
+
+from app.core.errors import AppError, NotFoundError
+from app.models.api_token import ApiToken
+
+TOKEN_PREFIX = "tend_pat_"
+MAX_TOKENS_PER_USER = 20
+
+
+def _hash_token(raw: str) -> str:
+    """SHA-256 hex digest. Fast (unsalted) on purpose: auth looks a token up by
+    its hash, so the digest must be reproducible without knowing the user."""
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def create_token(db: Session, user_id: uuid.UUID, name: str) -> tuple[ApiToken, str]:
+    """Create a token and return (record, raw_token). The raw token is only
+    available here — after this it exists solely as a hash."""
+    name = name.strip()
+    if not name:
+        raise AppError(code="validation_error", message="Token name is required", status_code=422)
+    if len(name) > 100:
+        raise AppError(
+            code="validation_error",
+            message="Token name must be 100 characters or fewer",
+            status_code=422,
+        )
+
+    existing = db.exec(select(ApiToken).where(ApiToken.user_id == user_id)).all()
+    if len(existing) >= MAX_TOKENS_PER_USER:
+        raise AppError(
+            code="token_limit_reached",
+            message=f"You can have at most {MAX_TOKENS_PER_USER} tokens",
+            status_code=422,
+        )
+
+    raw = TOKEN_PREFIX + secrets.token_urlsafe(32)
+    token = ApiToken(user_id=user_id, token_hash=_hash_token(raw), name=name)
+    db.add(token)
+    db.flush()
+    db.refresh(token)
+    return token, raw
+
+
+def list_tokens(db: Session, user_id: uuid.UUID) -> list[ApiToken]:
+    return list(
+        db.exec(
+            select(ApiToken).where(ApiToken.user_id == user_id).order_by(ApiToken.created_at.desc())
+        ).all()
+    )
+
+
+def revoke_token(db: Session, user_id: uuid.UUID, token_id: uuid.UUID) -> None:
+    token = db.get(ApiToken, token_id)
+    if token is None or token.user_id != user_id:
+        raise NotFoundError("Token not found")
+    db.delete(token)
+    db.flush()
+
+
+def authenticate(db: Session, raw: str) -> uuid.UUID | None:
+    """Resolve a raw ``tend_pat_...`` token to a user_id, or None if invalid.
+
+    Stamps ``last_used_at`` on success. Runs in its own transaction concern-free:
+    the caller's ``get_db`` owns commit/rollback.
+    """
+    if not raw.startswith(TOKEN_PREFIX):
+        return None
+    token = db.exec(select(ApiToken).where(ApiToken.token_hash == _hash_token(raw))).first()
+    if token is None:
+        return None
+    token.last_used_at = datetime.utcnow()
+    db.add(token)
+    db.flush()
+    return token.user_id

--- a/backend/app/services/placement_service.py
+++ b/backend/app/services/placement_service.py
@@ -1,0 +1,77 @@
+import uuid
+from datetime import date as date_type
+from datetime import datetime
+
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.models.task import Task
+from app.models.task_placement import TaskPlacement
+from app.services import task_service
+
+
+def record_placement(
+    db: Session,
+    user_id: uuid.UUID,
+    task_id: uuid.UUID,
+    *,
+    placement_date: date_type,
+    block_start: datetime | None = None,
+    block_type: str | None = None,
+    calendar_event_id: str | None = None,
+) -> TaskPlacement:
+    """Upsert a placement for (task, date). Re-placing the same task on the same
+    day updates the existing row rather than creating a duplicate.
+
+    Verifies the task belongs to the user (raises NotFoundError otherwise).
+    Tend records the fact; it never schedules.
+    """
+    task_service.get_task(db, user_id, task_id)  # ownership check
+
+    existing = db.exec(
+        select(TaskPlacement).where(
+            TaskPlacement.task_id == task_id,
+            TaskPlacement.date == placement_date,
+        )
+    ).first()
+
+    if existing is not None:
+        existing.block_start = block_start
+        existing.block_type = block_type
+        existing.calendar_event_id = calendar_event_id
+        existing.updated_at = datetime.utcnow()
+        db.add(existing)
+        db.flush()
+        return existing
+
+    placement = TaskPlacement(
+        task_id=task_id,
+        user_id=user_id,
+        date=placement_date,
+        block_start=block_start,
+        block_type=block_type,
+        calendar_event_id=calendar_event_id,
+    )
+    db.add(placement)
+    db.flush()
+    db.refresh(placement)
+    return placement
+
+
+def get_placements_for_date(
+    db: Session, user_id: uuid.UUID, placement_date: date_type
+) -> dict[uuid.UUID, TaskPlacement]:
+    """Return {task_id: placement} for a user on a given date, for enriching task
+    responses without an N+1 per task."""
+    rows = db.exec(
+        select(TaskPlacement).where(
+            TaskPlacement.user_id == user_id,
+            TaskPlacement.date == placement_date,
+        )
+    ).all()
+    return {p.task_id: p for p in rows}
+
+
+def load_tasks_with_placements(query):
+    """Eager-load placements onto a Task query (avoids lazy='raise')."""
+    return query.options(selectinload(Task.placements))

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -222,8 +222,11 @@ def update_task(
         task.size = size
     if status is not None:
         allowed = {
+            # pending → archived (let go / compost), archived → pending (restore),
+            # complete → pending (reopen, e.g. undo a triage "Done").
             TaskStatus.pending: {TaskStatus.archived},
             TaskStatus.archived: {TaskStatus.pending},
+            TaskStatus.complete: {TaskStatus.pending},
         }
         if status not in allowed.get(task.status, set()):
             raise AppError(
@@ -234,6 +237,9 @@ def update_task(
         # Restoring an archived task: reset triaged_at so it enters triage
         if task.status == TaskStatus.archived and status == TaskStatus.pending:
             task.triaged_at = None
+        # Reopening a completed task: clear completion timestamp.
+        if task.status == TaskStatus.complete and status == TaskStatus.pending:
+            task.completed_at = None
         task.status = status
 
     task.updated_at = datetime.utcnow()

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -6,7 +6,7 @@ from sqlmodel import Session, select
 from sqlmodel.sql.expression import SelectOfScalar
 
 from app.core.errors import AppError, NotFoundError
-from app.models.enums import BucketType, TaskStatus
+from app.models.enums import BucketType, SizeType, TaskStatus
 from app.models.task import Task
 from app.services import stats_service
 
@@ -48,6 +48,7 @@ def create_task(
     skip_triage_stamp: bool = False,
     important: bool = False,
     urgent: bool = False,
+    size: SizeType | None = None,
 ) -> Task:
     if len(text) > 500:
         raise AppError(
@@ -113,6 +114,7 @@ def create_task(
         triaged_at=None if skip_triage_stamp else date.today(),
         important=important,
         urgent=urgent,
+        size=size,
     )
     db.add(task)
     db.flush()
@@ -173,6 +175,7 @@ def update_task(
     notes: str | None | object = _UNSET,
     important: bool | None = None,
     urgent: bool | None = None,
+    size: SizeType | None | object = _UNSET,
 ) -> Task:
     task = get_task(db, user_id, task_id)
 
@@ -215,6 +218,8 @@ def update_task(
         task.important = important
     if urgent is not None:
         task.urgent = urgent
+    if size is not _UNSET:
+        task.size = size
     if status is not None:
         allowed = {
             TaskStatus.pending: {TaskStatus.archived},

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine  # noqa: E402
 from sqlmodel import Session  # noqa: E402
 
 from app.core.deps import get_db  # noqa: E402
-from app.core.security import get_current_user_id  # noqa: E402
+from app.core.security import get_current_user_id, get_user_id_allow_pat  # noqa: E402
 from app.main import app  # noqa: E402
 from app.models.domain import Domain
 from app.models.enums import AuthProvider, BucketType, TaskStatus
@@ -50,6 +50,9 @@ def client(db: Session) -> TestClient:
 
     app.dependency_overrides[get_db] = _override_db
     app.dependency_overrides[get_current_user_id] = _override_user
+    # PAT-accepting endpoints use a distinct dependency; mock it the same way so
+    # the transactional/auth bypass applies there too.
+    app.dependency_overrides[get_user_id_allow_pat] = _override_user
 
     with TestClient(app) as c:
         yield c

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -1,0 +1,120 @@
+"""Tests for personal access tokens (#212)."""
+
+import uuid
+
+import pytest
+from sqlmodel import Session
+
+from app.core.deps import get_db
+from app.core.security import get_current_user_id, get_user_id_allow_pat
+from app.main import app
+from app.models.user import User
+from app.services import api_token_service
+
+
+class TestApiTokenService:
+    def test_create_returns_raw_token_once(self, db: Session, test_user: User):
+        token, raw = api_token_service.create_token(db, test_user.id, "Plot")
+        assert raw.startswith("tend_pat_")
+        assert token.name == "Plot"
+        # Only the hash is stored, never the raw value.
+        assert token.token_hash != raw
+        assert token.token_hash == api_token_service._hash_token(raw)
+
+    def test_authenticate_valid(self, db: Session, test_user: User):
+        _, raw = api_token_service.create_token(db, test_user.id, "Plot")
+        assert api_token_service.authenticate(db, raw) == test_user.id
+
+    def test_authenticate_stamps_last_used(self, db: Session, test_user: User):
+        token, raw = api_token_service.create_token(db, test_user.id, "Plot")
+        assert token.last_used_at is None
+        api_token_service.authenticate(db, raw)
+        assert token.last_used_at is not None
+
+    def test_authenticate_invalid_returns_none(self, db: Session, test_user: User):
+        assert api_token_service.authenticate(db, "tend_pat_nope") is None
+        assert api_token_service.authenticate(db, "not_a_pat") is None
+
+    def test_authenticate_revoked_returns_none(self, db: Session, test_user: User):
+        token, raw = api_token_service.create_token(db, test_user.id, "Plot")
+        api_token_service.revoke_token(db, test_user.id, token.id)
+        assert api_token_service.authenticate(db, raw) is None
+
+    def test_revoke_other_users_token_rejected(self, db: Session, test_user: User):
+        token, _ = api_token_service.create_token(db, test_user.id, "Plot")
+        with pytest.raises(Exception):
+            api_token_service.revoke_token(db, uuid.uuid4(), token.id)
+
+    def test_token_limit(self, db: Session, test_user: User):
+        for i in range(api_token_service.MAX_TOKENS_PER_USER):
+            api_token_service.create_token(db, test_user.id, f"t{i}")
+        with pytest.raises(Exception):
+            api_token_service.create_token(db, test_user.id, "one too many")
+
+
+class TestApiTokenEndpoints:
+    def test_create_list_revoke(self, client, test_user):
+        r = client.post("/api-tokens", json={"name": "Raycast"})
+        assert r.status_code == 201
+        body = r.json()
+        assert body["token"].startswith("tend_pat_")
+        token_id = body["id"]
+
+        r = client.get("/api-tokens")
+        assert r.status_code == 200
+        listed = r.json()
+        assert len(listed) == 1
+        # The list endpoint never leaks the raw token.
+        assert "token" not in listed[0]
+
+        r = client.delete(f"/api-tokens/{token_id}")
+        assert r.status_code == 204
+        assert client.get("/api-tokens").json() == []
+
+    def test_empty_name_rejected(self, client, test_user):
+        assert client.post("/api-tokens", json={"name": "  "}).status_code == 422
+
+
+class TestPatScoping:
+    """A PAT works ONLY on endpoints using get_user_id_allow_pat; the proxy-JWT
+    override is removed here so real auth runs."""
+
+    @pytest.fixture()
+    def real_auth_client(self, db):
+        from fastapi.testclient import TestClient
+
+        def _override_db():
+            yield db
+
+        app.dependency_overrides[get_db] = _override_db
+        # Deliberately do NOT override the auth dependencies.
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_user_id_allow_pat, None)
+        with TestClient(app) as c:
+            yield c
+        app.dependency_overrides.clear()
+
+    def test_pat_works_on_scoped_endpoint(self, real_auth_client, db, test_user):
+        _, raw = api_token_service.create_token(db, test_user.id, "Plot")
+        r = real_auth_client.post(
+            "/tasks",
+            json={"text": "from a shortcut", "bucket": "today"},
+            headers={"Authorization": f"Bearer {raw}"},
+        )
+        assert r.status_code == 201
+
+    def test_pat_rejected_on_unscoped_endpoint(self, real_auth_client, db, test_user):
+        _, raw = api_token_service.create_token(db, test_user.id, "Plot")
+        # DELETE /tasks/{id} uses get_current_user_id (proxy-JWT only), so a PAT
+        # must be rejected there even though it's a valid token.
+        r = real_auth_client.delete(
+            f"/tasks/{uuid.uuid4()}",
+            headers={"Authorization": f"Bearer {raw}"},
+        )
+        assert r.status_code == 401
+
+    def test_revoked_pat_rejected(self, real_auth_client, db, test_user):
+        token, raw = api_token_service.create_token(db, test_user.id, "Plot")
+        api_token_service.revoke_token(db, test_user.id, token.id)
+        r = real_auth_client.get("/tasks", headers={"Authorization": f"Bearer {raw}"})
+        assert r.status_code == 401

--- a/backend/tests/test_composter.py
+++ b/backend/tests/test_composter.py
@@ -131,8 +131,28 @@ class TestComposter:
         assert task.status == TaskStatus.pending
         assert task.triaged_at is None
 
+    def test_reopen_complete_to_pending_allowed(self, client, test_user, db):
+        """complete→pending is allowed (reopen, e.g. undo a triage "Done");
+        completed_at is cleared."""
+        from datetime import datetime
+
+        task = Task(
+            user_id=test_user.id,
+            text="Done task",
+            bucket=BucketType.today,
+            status=TaskStatus.complete,
+            completed_at=datetime.utcnow(),
+        )
+        db.add(task)
+        db.flush()
+
+        r = client.patch(f"/tasks/{task.id}", json={"status": "pending"})
+        assert r.status_code == 200
+        assert r.json()["status"] == "pending"
+        assert r.json()["completed_at"] is None
+
     def test_invalid_status_transition_rejected(self, client, test_user, db):
-        """Cannot transition complete→pending via PATCH."""
+        """complete→archived is not a valid transition."""
         task = Task(
             user_id=test_user.id,
             text="Done task",
@@ -142,5 +162,5 @@ class TestComposter:
         db.add(task)
         db.flush()
 
-        r = client.patch(f"/tasks/{task.id}", json={"status": "pending"})
+        r = client.patch(f"/tasks/{task.id}", json={"status": "archived"})
         assert r.status_code == 422

--- a/backend/tests/test_placements.py
+++ b/backend/tests/test_placements.py
@@ -1,0 +1,72 @@
+"""Tests for task placements — the Plot time-block write-back (#215)."""
+
+from datetime import date
+
+from app.models.task import Task
+
+
+class TestPlacementEndpoint:
+    def test_record_placement(self, client, test_user, test_tasks):
+        today_task = next(t for t in test_tasks if t.bucket == "today")
+        r = client.post(
+            f"/tasks/{today_task.id}/placements",
+            json={
+                "date": date.today().isoformat(),
+                "block_start": "2026-07-06T09:00:00",
+                "block_type": "deep",
+                "calendar_event_id": "evt_123",
+            },
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["placement"]["block_type"] == "deep"
+        assert body["placement"]["calendar_event_id"] == "evt_123"
+
+    def test_placement_upserts_on_same_day(self, client, test_user, test_tasks):
+        t = test_tasks[0]
+        d = date.today().isoformat()
+        client.post(f"/tasks/{t.id}/placements", json={"date": d, "block_type": "deep"})
+        r = client.post(f"/tasks/{t.id}/placements", json={"date": d, "block_type": "admin"})
+        assert r.status_code == 201
+        assert r.json()["placement"]["block_type"] == "admin"
+
+    def test_placement_shows_on_task_list(self, client, test_user, test_tasks):
+        t = next(t for t in test_tasks if t.bucket == "today")
+        client.post(
+            f"/tasks/{t.id}/placements",
+            json={"date": date.today().isoformat(), "block_type": "deep"},
+        )
+        r = client.get("/tasks?bucket=today")
+        placed = {row["id"]: row["placement"] for row in r.json()}
+        assert placed[str(t.id)] is not None
+        assert placed[str(t.id)]["block_type"] == "deep"
+
+    def test_placement_for_missing_task_404(self, client, test_user):
+        import uuid
+
+        r = client.post(
+            f"/tasks/{uuid.uuid4()}/placements",
+            json={"date": date.today().isoformat()},
+        )
+        assert r.status_code == 404
+
+    def test_winddown_includes_placement(self, client, test_user, test_tasks):
+        t = next(t for t in test_tasks if t.bucket == "today")
+        client.post(
+            f"/tasks/{t.id}/placements",
+            json={"date": date.today().isoformat(), "block_type": "deep"},
+        )
+        r = client.get("/triage/winddown")
+        assert r.status_code == 200
+        rows = {row["id"]: row["placement"] for row in r.json()["tasks"]}
+        assert rows[str(t.id)] is not None
+
+    def test_deleting_task_cascades_placement(self, client, test_user, test_tasks, db):
+        t = test_tasks[0]
+        client.post(
+            f"/tasks/{t.id}/placements",
+            json={"date": date.today().isoformat(), "block_type": "deep"},
+        )
+        client.delete(f"/tasks/{t.id}")
+        # Task gone → placement gone (FK ON DELETE CASCADE).
+        assert db.get(Task, t.id) is None

--- a/backend/tests/test_size.py
+++ b/backend/tests/test_size.py
@@ -1,0 +1,30 @@
+"""Tests for the task size field (#216)."""
+
+
+class TestTaskSize:
+    def test_create_with_size(self, client, test_user):
+        r = client.post("/tasks", json={"text": "sized task", "bucket": "today", "size": "m"})
+        assert r.status_code == 201
+        assert r.json()["size"] == "m"
+
+    def test_create_without_size_is_null(self, client, test_user):
+        r = client.post("/tasks", json={"text": "unsized", "bucket": "today"})
+        assert r.status_code == 201
+        assert r.json()["size"] is None
+
+    def test_invalid_size_rejected(self, client, test_user):
+        r = client.post("/tasks", json={"text": "bad", "bucket": "today", "size": "xl"})
+        assert r.status_code == 422
+
+    def test_update_size(self, client, test_user, test_tasks):
+        t = test_tasks[0]
+        r = client.patch(f"/tasks/{t.id}", json={"size": "l"})
+        assert r.status_code == 200
+        assert r.json()["size"] == "l"
+
+    def test_size_exposed_in_list(self, client, test_user, test_tasks):
+        t = test_tasks[0]
+        client.patch(f"/tasks/{t.id}", json={"size": "s"})
+        r = client.get("/tasks")
+        sizes = {row["id"]: row["size"] for row in r.json()}
+        assert sizes[str(t.id)] == "s"

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,14 @@
+// Minimal service worker: exists only to make Tend installable as a PWA.
+// Intentionally no offline caching or background sync — capture goes straight
+// to the network. Keeping it a no-op avoids stale-asset and sync-conflict bugs.
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Pass-through fetch handler. Required for the app to count as installable in
+// some browsers; deliberately does not cache.
+self.addEventListener("fetch", () => {});

--- a/frontend/src/app/(app)/capture/page.tsx
+++ b/frontend/src/app/(app)/capture/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import type { Domain } from "@/lib/api-types";
+import { createTask, getDomains } from "@/lib/api";
+import { parseCapture } from "@/lib/parse-capture";
+
+export default function CapturePage() {
+  return (
+    <Suspense>
+      <CaptureContent />
+    </Suspense>
+  );
+}
+
+function CaptureContent() {
+  const searchParams = useSearchParams();
+  const [text, setText] = useState("");
+  const [domains, setDomains] = useState<Domain[]>([]);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  // Seed the field from the OS share sheet (title + text + url).
+  useEffect(() => {
+    const parts = [
+      searchParams.get("title"),
+      searchParams.get("text"),
+      searchParams.get("url"),
+    ].filter(Boolean);
+    setText(parts.join(" ").trim());
+  }, [searchParams]);
+
+  useEffect(() => {
+    getDomains()
+      .then(setDomains)
+      .catch((err) => console.error("Failed to load domains:", err));
+  }, []);
+
+  async function handleSave() {
+    const parsed = parseCapture(text, domains);
+    if (!parsed.text || status === "saving") return;
+    setStatus("saving");
+    try {
+      await createTask({
+        text: parsed.text,
+        bucket: parsed.bucket ?? "today",
+        domain_id: parsed.domainId,
+        important: parsed.important,
+        urgent: parsed.urgent,
+        size: parsed.size,
+      });
+      setStatus("saved");
+      setText("");
+    } catch (err) {
+      console.error("Failed to capture task:", err);
+      setStatus("error");
+    }
+  }
+
+  if (status === "saved") {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 text-center space-y-6">
+        <h1 className="text-xl font-semibold text-text-primary">Captured</h1>
+        <p className="text-sm text-text-secondary">It&apos;s waiting in Tend.</p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={() => setStatus("idle")}
+            className="min-h-[44px] px-4 rounded-lg border border-border text-sm text-text-secondary hover:bg-bg-hover"
+          >
+            Add another
+          </button>
+          <Link
+            href="/today"
+            className="min-h-[44px] px-4 flex items-center rounded-lg bg-accent-blue text-white text-sm hover:bg-accent-blue/90"
+          >
+            Go to Today
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-md px-4 py-12 space-y-4">
+      <h1 className="text-xl font-semibold text-text-primary">Quick capture</h1>
+      <p className="text-xs text-text-muted">
+        Tokens work here too: <code>#domain</code> <code>!</code> <code>u!</code>{" "}
+        <code>&gt;later</code> <code>~m</code>
+      </p>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            handleSave();
+          }
+        }}
+        autoFocus
+        rows={3}
+        placeholder="What's on your mind?"
+        maxLength={500}
+        className="w-full rounded-lg bg-bg-card border border-border px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-text-muted resize-none"
+      />
+      {status === "error" && (
+        <p className="text-xs text-accent-red">Couldn&apos;t save. Try again.</p>
+      )}
+      <button
+        onClick={handleSave}
+        disabled={!text.trim() || status === "saving"}
+        className="w-full min-h-[44px] rounded-lg bg-text-primary text-bg-page text-sm font-medium hover:opacity-90 disabled:opacity-40"
+      >
+        {status === "saving" ? "Saving…" : "Capture"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -52,6 +52,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const [onboardingChecked, setOnboardingChecked] = useState(false);
   const [showWinddownModal, setShowWinddownModal] = useState(false);
   const [triagePending, setTriagePending] = useState(false);
+  const [triageCount, setTriageCount] = useState(0);
   const [showTriageBanner, setShowTriageBanner] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const [user, setUser] = useState<User | null>(null);
@@ -158,6 +159,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       .then((q) => {
         if (!q.triage_complete && q.tasks.length > 0) {
           setTriagePending(true);
+          setTriageCount(q.tasks.length);
           // Banner is dismissed via hard skip, but the rail link still shows.
           if (!isTriageSkippedToday()) {
             setShowTriageBanner(true);
@@ -165,6 +167,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         } else {
           markTriageDone();
           setTriagePending(false);
+          setTriageCount(0);
         }
       })
       .catch((err) => {
@@ -230,7 +233,13 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               >
                 <NavIcon name="review" className="text-accent-blue" />
                 <span className="flex-1 text-left">Morning triage</span>
-                <span className="h-2 w-2 rounded-full bg-accent-blue shrink-0" />
+                {triageCount > 0 ? (
+                  <span className="min-w-5 px-1.5 h-5 rounded-full bg-accent-blue text-white text-[11px] font-semibold flex items-center justify-center shrink-0">
+                    {triageCount}
+                  </span>
+                ) : (
+                  <span className="h-2 w-2 rounded-full bg-accent-blue shrink-0" />
+                )}
               </button>
             )}
             {mainNavItems.map((item) => {

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -19,6 +19,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/components/theme-provider";
 import { ApiError } from "@/lib/api";
+import { ApiTokensSection } from "@/components/api-tokens-section";
 import { PRESET_COLORS, FREE_DOMAIN_LIMIT, PRO_DOMAIN_LIMIT } from "@/lib/constants";
 
 export default function SettingsPage() {
@@ -394,6 +395,9 @@ function SettingsContent() {
           Sign out
         </button>
       </section>
+
+      {/* Personal access tokens */}
+      <ApiTokensSection />
 
       {/* Feedback */}
       <section className="space-y-3 pt-4 border-t border-border">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { ThemeProvider } from "@/components/theme-provider";
+import { PwaRegister } from "@/components/pwa-register";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -46,6 +47,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen antialiased">
         <ThemeProvider>{children}</ThemeProvider>
+        <PwaRegister />
       </body>
     </html>
   );

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+
+// The Web App Manifest. Includes a share_target so the OS share sheet can send
+// text straight into Tend's capture page. `share_target` isn't in Next's
+// Manifest type yet, so we extend it locally.
+type ManifestWithShareTarget = MetadataRoute.Manifest & {
+  share_target?: {
+    action: string;
+    method: "GET" | "POST";
+    params: { title?: string; text?: string; url?: string };
+  };
+};
+
+export default function manifest(): ManifestWithShareTarget {
+  return {
+    name: "Tend",
+    short_name: "Tend",
+    description: "A quiet app for what matters today.",
+    start_url: "/today",
+    display: "standalone",
+    background_color: "#0f0f0f",
+    theme_color: "#0f0f0f",
+    icons: [
+      { src: "/favicon.svg", sizes: "any", type: "image/svg+xml", purpose: "any" },
+    ],
+    share_target: {
+      action: "/capture",
+      method: "GET",
+      params: { title: "title", text: "text", url: "url" },
+    },
+  };
+}

--- a/frontend/src/components/api-tokens-section.tsx
+++ b/frontend/src/components/api-tokens-section.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { ApiToken } from "@/lib/api-types";
+import { getApiTokens, createApiToken, deleteApiToken } from "@/lib/api";
+
+export function ApiTokensSection() {
+  const [tokens, setTokens] = useState<ApiToken[]>([]);
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+  // The raw token is shown exactly once, right after creation.
+  const [freshToken, setFreshToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const refresh = useCallback(() => {
+    getApiTokens()
+      .then(setTokens)
+      .catch((err) => console.error("Failed to load tokens:", err));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function handleCreate() {
+    const trimmed = name.trim();
+    if (!trimmed || creating) return;
+    setCreating(true);
+    try {
+      const created = await createApiToken(trimmed);
+      setFreshToken(created.token);
+      setCopied(false);
+      setName("");
+      refresh();
+    } catch (err) {
+      console.error("Failed to create token:", err);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    try {
+      await deleteApiToken(id);
+      refresh();
+    } catch (err) {
+      console.error("Failed to revoke token:", err);
+    }
+  }
+
+  function copyFresh() {
+    if (!freshToken) return;
+    void navigator.clipboard?.writeText(freshToken).then(() => setCopied(true));
+  }
+
+  return (
+    <section className="space-y-3 pt-4 border-t border-border">
+      <div>
+        <h2 className="text-sm font-medium text-text-primary">Personal access tokens</h2>
+        <p className="text-xs text-text-muted mt-0.5">
+          Create a token for Plot, Raycast, iOS Shortcuts, or a script to capture tasks. Treat it
+          like a password.
+        </p>
+      </div>
+
+      {/* Freshly created token — shown once */}
+      {freshToken && (
+        <div className="rounded-lg border border-accent-blue/40 bg-accent-blue/10 p-3 space-y-2">
+          <p className="text-xs text-text-secondary">
+            Copy this token now — you won&apos;t be able to see it again.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 min-w-0 truncate rounded bg-bg-card border border-border px-2 py-1.5 font-mono text-xs text-text-primary">
+              {freshToken}
+            </code>
+            <button
+              type="button"
+              onClick={copyFresh}
+              className="shrink-0 min-h-[44px] px-3 rounded-md text-xs bg-accent-blue text-white hover:opacity-90"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setFreshToken(null)}
+            className="text-xs text-text-muted hover:text-text-secondary"
+          >
+            Done
+          </button>
+        </div>
+      )}
+
+      {/* Create form */}
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleCreate();
+            }
+          }}
+          placeholder="Token name (e.g. Plot)"
+          maxLength={100}
+          className="flex-1 rounded-md bg-bg-card border border-border px-3 min-h-[44px] text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-text-muted"
+        />
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={!name.trim() || creating}
+          className="shrink-0 min-h-[44px] px-4 rounded-md text-sm bg-text-primary text-bg-page hover:opacity-90 disabled:opacity-40"
+        >
+          Create
+        </button>
+      </div>
+
+      {/* Existing tokens */}
+      {tokens.length > 0 && (
+        <ul className="space-y-1.5">
+          {tokens.map((t) => (
+            <li
+              key={t.id}
+              className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="text-sm text-text-primary truncate">{t.name}</p>
+                <p className="text-xs text-text-muted">
+                  {t.last_used_at
+                    ? `Last used ${new Date(t.last_used_at).toLocaleDateString()}`
+                    : "Never used"}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRevoke(t.id)}
+                className="shrink-0 text-xs text-red-400 hover:text-red-300"
+              >
+                Revoke
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/pwa-register.tsx
+++ b/frontend/src/components/pwa-register.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+
+/** Registers the minimal service worker so Tend is installable as a PWA. */
+export function PwaRegister() {
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      console.error("Service worker registration failed:", err);
+    });
+  }, []);
+  return null;
+}

--- a/frontend/src/components/task-input.tsx
+++ b/frontend/src/components/task-input.tsx
@@ -3,9 +3,10 @@
 import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
 import type { BucketType, Domain } from "@/lib/api-types";
 import { createTask } from "@/lib/api";
+import { parseCapture } from "@/lib/parse-capture";
 import { cn } from "@/lib/utils";
 
-type Phase = "typing" | "selecting" | "submitting";
+type Phase = "typing" | "selecting";
 
 interface TaskInputProps {
   bucket: BucketType;
@@ -17,10 +18,13 @@ export interface TaskInputHandle {
   focus: () => void;
 }
 
-export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function TaskInput({ bucket, domains, onCreated }, ref) {
+export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function TaskInput(
+  { bucket, domains, onCreated },
+  ref,
+) {
   const [text, setText] = useState("");
   const [phase, setPhase] = useState<Phase>("typing");
-  // Index into [undefined, ...domains] where undefined = "None"
+  // Index into [None, ...domains] where 0 = "None"
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [important, setImportant] = useState(false);
   const [urgent, setUrgent] = useState(false);
@@ -32,10 +36,7 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
   }));
 
   const hasDomains = domains.length > 0;
-  // Options: [undefined (None), domain0, domain1, ...]
   const optionCount = domains.length + 1;
-
-  const [shouldRefocus, setShouldRefocus] = useState(false);
 
   const resetToTyping = useCallback(() => {
     setText("");
@@ -43,37 +44,50 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
     setImportant(false);
     setUrgent(false);
     setPhase("typing");
-    setShouldRefocus(true);
+    // Refocus synchronously — the input is never disabled, so rapid-fire works.
+    inputRef.current?.focus();
   }, []);
 
-  const submitTask = useCallback(async (taskText: string, domainIndex: number, isImportant: boolean, isUrgent: boolean) => {
-    setPhase("submitting");
-    const domainId = domainIndex > 0 ? domains[domainIndex - 1]?.id : undefined;
-    try {
-      await createTask({
-        text: taskText,
-        bucket,
-        domain_id: domainId,
-        important: isImportant,
-        urgent: isUrgent,
-      });
-      onCreated();
-    } catch (err) {
-      console.error("Failed to create task:", err);
-    }
-    resetToTyping();
-  }, [bucket, domains, onCreated, resetToTyping]);
+  // Fire a create. Clears the input immediately so the next thought can start
+  // typing before the network round-trip finishes (capture must be instant).
+  const submit = useCallback(
+    (opts?: { domainId?: string; forceImportant?: boolean; forceUrgent?: boolean }) => {
+      const parsed = parseCapture(text, domains);
+      if (!parsed.text) {
+        resetToTyping();
+        return;
+      }
+      const body = {
+        text: parsed.text,
+        bucket: parsed.bucket ?? bucket,
+        domain_id: opts?.domainId ?? parsed.domainId,
+        important: parsed.important || !!opts?.forceImportant,
+        urgent: parsed.urgent || !!opts?.forceUrgent,
+        size: parsed.size,
+      };
+      resetToTyping();
+      void (async () => {
+        try {
+          await createTask(body);
+          onCreated();
+        } catch (err) {
+          console.error("Failed to create task:", err);
+        }
+      })();
+    },
+    [text, domains, bucket, onCreated, resetToTyping],
+  );
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key !== "Enter") return;
-    e.preventDefault();
-    const trimmed = text.trim();
-    if (!trimmed || phase !== "typing") return;
-
-    if (!hasDomains) {
-      // No domains — skip Phase 2, create immediately
-      submitTask(trimmed, 0, important, urgent);
-    } else {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (!text.trim()) return;
+      submit();
+      return;
+    }
+    // Tab opens the domain/priority picker (browse) instead of submitting.
+    if (e.key === "Tab" && hasDomains && text.trim() && phase === "typing") {
+      e.preventDefault();
       setPhase("selecting");
     }
   }
@@ -106,38 +120,31 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
       }
       case "Enter": {
         e.preventDefault();
-        submitTask(text.trim(), selectedIndex, important, urgent);
+        submit({
+          domainId: selectedIndex > 0 ? domains[selectedIndex - 1]?.id : undefined,
+          forceImportant: important,
+          forceUrgent: urgent,
+        });
         break;
       }
       case "Escape": {
         e.preventDefault();
-        // Skip domain, create with no domain
-        submitTask(text.trim(), 0, important, urgent);
+        setPhase("typing");
+        inputRef.current?.focus();
         break;
       }
     }
   }
 
-  // Focus chip container when entering Phase 2
+  // Focus chip container when entering the picker.
   useEffect(() => {
     if (phase === "selecting") {
       chipContainerRef.current?.focus();
     }
   }, [phase]);
 
-  // Refocus text input after task creation (waits for React to re-enable the input)
-  useEffect(() => {
-    if (shouldRefocus && phase === "typing") {
-      inputRef.current?.focus();
-      setShouldRefocus(false);
-    }
-  }, [shouldRefocus, phase]);
-
-  const isDisabled = phase === "submitting";
-
   return (
     <div className="rounded-lg bg-bg-card border border-border px-3 py-2.5 my-2">
-      {/* Phase 1: Text input */}
       <div className="flex items-center gap-2">
         <input
           ref={inputRef}
@@ -145,17 +152,16 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Add a task..."
+          placeholder="Add a task…  (#domain  !  u!  >later  ~m)"
           maxLength={500}
-          disabled={isDisabled || phase === "selecting"}
-          className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none disabled:opacity-50"
+          className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none"
         />
-        {phase === "typing" && text.length > 0 && (
+        {text.length > 0 && (
           <span className="text-xs text-text-muted shrink-0">{text.length}/500</span>
         )}
       </div>
 
-      {/* Phase 2: Domain chip selector */}
+      {/* Picker (Tab): domain chips + priority toggles */}
       <div
         className={`overflow-hidden transition-all duration-200 ease-out ${
           phase === "selecting" ? "max-h-12 opacity-100 mt-2" : "max-h-0 opacity-0"
@@ -169,14 +175,10 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
           role="listbox"
           aria-label="Select a domain"
         >
-          {/* "None" option */}
           <button
             type="button"
             tabIndex={-1}
-            onClick={() => {
-              setSelectedIndex(0);
-              submitTask(text.trim(), 0, important, urgent);
-            }}
+            onClick={() => submit({})}
             className={`shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs transition-all ${
               selectedIndex === 0
                 ? "bg-text-muted/20 text-text-primary border border-text-secondary"
@@ -189,7 +191,6 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
             None
           </button>
 
-          {/* Domain options */}
           {domains.map((domain, i) => {
             const optIndex = i + 1;
             const isActive = selectedIndex === optIndex;
@@ -198,10 +199,9 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
                 key={domain.id}
                 type="button"
                 tabIndex={-1}
-                onClick={() => {
-                  setSelectedIndex(optIndex);
-                  submitTask(text.trim(), optIndex, important, urgent);
-                }}
+                onClick={() =>
+                  submit({ domainId: domain.id, forceImportant: important, forceUrgent: urgent })
+                }
                 className={`shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs transition-all ${
                   isActive
                     ? "bg-text-muted/20 text-text-primary border border-text-secondary"
@@ -210,26 +210,21 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
                 role="option"
                 aria-selected={isActive}
               >
-                <span
-                  className="h-2 w-2 rounded-full"
-                  style={{ backgroundColor: domain.color }}
-                />
+                <span className="h-2 w-2 rounded-full" style={{ backgroundColor: domain.color }} />
                 {domain.name}
               </button>
             );
           })}
 
-          {/* Divider */}
           <span className="h-4 w-px bg-border mx-1" aria-hidden />
 
-          {/* Important toggle */}
           <button
             type="button"
             tabIndex={-1}
             onClick={() => setImportant((v) => !v)}
             aria-pressed={important}
             aria-label={important ? "Remove important" : "Mark as important"}
-            title={important ? "Important (press !)" : "Important (press !)"}
+            title="Important (press !)"
             className={cn(
               "shrink-0 font-mono text-[11px] h-6 w-6 rounded border flex items-center justify-center transition-all",
               important
@@ -240,14 +235,13 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
             !
           </button>
 
-          {/* Urgent toggle */}
           <button
             type="button"
             tabIndex={-1}
             onClick={() => setUrgent((v) => !v)}
             aria-pressed={urgent}
             aria-label={urgent ? "Remove urgent" : "Mark as urgent"}
-            title={urgent ? "Urgent (press u)" : "Urgent (press u)"}
+            title="Urgent (press u)"
             className={cn(
               "shrink-0 text-[11px] h-6 w-6 rounded border flex items-center justify-center transition-all",
               urgent
@@ -258,9 +252,7 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
             ⚡
           </button>
 
-          <span className="text-xs text-text-muted ml-1">
-            ← → ! u then Enter
-          </span>
+          <span className="text-xs text-text-muted ml-1">← → ! u · Enter · Esc</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/task-item.tsx
+++ b/frontend/src/components/task-item.tsx
@@ -445,6 +445,44 @@ export function TaskItem({ task, domains, onMutate, isMIT, onSetMIT, compact, is
           </span>
         )}
 
+        {/* Size glyph */}
+        {task.size && (
+          <span
+            className="shrink-0 font-mono text-[10px] leading-none h-4 w-4 rounded border border-border text-text-muted flex items-center justify-center uppercase"
+            title={
+              task.size === "s"
+                ? "Small (under 30 min)"
+                : task.size === "m"
+                  ? "Medium (about an hour)"
+                  : "Large (half a day)"
+            }
+          >
+            {task.size}
+          </span>
+        )}
+
+        {/* Placement badge (Plot time block) */}
+        {task.placement && (
+          <span
+            className="shrink-0 text-[10px] font-medium text-accent-blue/80 rounded bg-accent-blue/10 px-1.5 py-0.5"
+            title="Placed into a time block by Plot"
+          >
+            {[
+              task.placement.block_type
+                ? task.placement.block_type[0].toUpperCase() + task.placement.block_type.slice(1)
+                : "Block",
+              task.placement.block_start
+                ? new Date(task.placement.block_start).toLocaleTimeString([], {
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </span>
+        )}
+
         {/* Note indicator */}
         {!compact && !isSubtask && hasNote && (
           <button

--- a/frontend/src/components/triage-card.tsx
+++ b/frontend/src/components/triage-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { StickyNote } from "lucide-react";
-import type { Task, TriageAction, TriageResult, BucketType } from "@/lib/api-types";
+import type { Task, TriageAction, TriageResult, BucketType, TaskSize } from "@/lib/api-types";
 import { submitTriage, updateTask } from "@/lib/api";
 import { DomainBadge } from "@/components/domain-badge";
 import { formatAge, cn } from "@/lib/utils";
@@ -13,12 +13,34 @@ interface TriageCardProps {
   onAction: (result: TriageResult) => void;
   showHints?: boolean;
   isWinddown?: boolean;
+  onUndo?: () => void;
+  canUndo?: boolean;
 }
 
-export function TriageCard({ task, progress, onAction, showHints = false, isWinddown = false }: TriageCardProps) {
+export function TriageCard({
+  task,
+  progress,
+  onAction,
+  showHints = false,
+  isWinddown = false,
+  onUndo,
+  canUndo = false,
+}: TriageCardProps) {
   const [rewriteMode, setRewriteMode] = useState(false);
   const [rewriteText, setRewriteText] = useState(task.text);
   const [loading, setLoading] = useState(false);
+  const [size, setSizeState] = useState<TaskSize | null>(task.size);
+
+  // Set size during triage (keys 1/2/3). Optimistic; fire-and-forget.
+  const setSize = useCallback(
+    (next: TaskSize) => {
+      setSizeState(next);
+      updateTask(task.id, { size: next }).catch((err) =>
+        console.error("Failed to set size:", err),
+      );
+    },
+    [task.id],
+  );
 
   const [rewriteDismissed, setRewriteDismissed] = useState(false);
   const [noteExpanded, setNoteExpanded] = useState(false);
@@ -32,12 +54,12 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
   const hasNote = !!currentNotes;
   const completedChildren = task.children.filter((c) => c.status === "complete").length;
 
-  function startNoteEdit() {
+  const startNoteEdit = useCallback(() => {
     setNoteDraft(currentNotes ?? "");
     setNoteEditing(true);
     setNoteExpanded(true);
     setNoteError(null);
-  }
+  }, [currentNotes]);
 
   function cancelNoteEdit() {
     setNoteDraft(currentNotes ?? "");
@@ -81,22 +103,108 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
     }
   }, [noteEditing]);
 
-  async function handleAction(action: TriageAction, bucket?: BucketType) {
-    if (loading) return;
-    setLoading(true);
-    const body: { action: TriageAction; bucket?: BucketType; rewritten_text?: string } = { action };
-    if (bucket) body.bucket = bucket;
-    if (rewriteMode && rewriteText.trim() !== task.text) {
-      body.rewritten_text = rewriteText.trim();
+  const handleAction = useCallback(
+    async (action: TriageAction, bucket?: BucketType) => {
+      if (loading) return;
+      setLoading(true);
+      try {
+        if (action === "kill") {
+          // "Let go" is a reversible soft-archive (not a hard delete) so undo
+          // can restore it. Archived tasks remain recoverable on the Someday page.
+          await updateTask(task.id, { status: "archived" });
+          onAction({
+            task_id: task.id,
+            action: "kill",
+            same_text_warning: false,
+            triage_complete: false,
+            remaining: 1,
+          });
+          return;
+        }
+        const body: { action: TriageAction; bucket?: BucketType; rewritten_text?: string } = {
+          action,
+        };
+        if (bucket) body.bucket = bucket;
+        if (rewriteMode && rewriteText.trim() !== task.text) {
+          body.rewritten_text = rewriteText.trim();
+        }
+        const result = await submitTriage(task.id, body);
+        onAction(result);
+      } catch (err) {
+        console.error("Triage action failed:", err);
+        setLoading(false);
+      }
+    },
+    [loading, task.id, task.text, rewriteMode, rewriteText, onAction],
+  );
+
+  // Keyboard-driven triage: single keys act on the current card. Ignored while
+  // editing text (rewrite/note) so typing isn't hijacked.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (rewriteMode || noteEditing) return;
+      const el = document.activeElement;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA")) return;
+
+      switch (e.key.toLowerCase()) {
+        case "t":
+          e.preventDefault();
+          handleAction("confirm");
+          break;
+        case "s":
+          e.preventDefault();
+          handleAction("defer", "soon");
+          break;
+        case "l":
+          e.preventDefault();
+          handleAction("defer", "later");
+          break;
+        case "o":
+          e.preventDefault();
+          handleAction("defer", "someday");
+          break;
+        case "d":
+          e.preventDefault();
+          handleAction("complete");
+          break;
+        case "x":
+          e.preventDefault();
+          handleAction("kill");
+          break;
+        case "1":
+          e.preventDefault();
+          setSize("s");
+          break;
+        case "2":
+          e.preventDefault();
+          setSize("m");
+          break;
+        case "3":
+          e.preventDefault();
+          setSize("l");
+          break;
+        case "n":
+          e.preventDefault();
+          startNoteEdit();
+          break;
+        case "r":
+          if (!isWinddown) {
+            e.preventDefault();
+            setRewriteMode(true);
+          }
+          break;
+        case "z":
+          if (onUndo && canUndo) {
+            e.preventDefault();
+            onUndo();
+          }
+          break;
+      }
     }
-    try {
-      const result = await submitTriage(task.id, body);
-      onAction(result);
-    } catch (err) {
-      console.error("Triage action failed:", err);
-      setLoading(false);
-    }
-  }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [handleAction, rewriteMode, noteEditing, isWinddown, onUndo, canUndo, startNoteEdit, setSize]);
 
   return (
     <div className="flex flex-col items-center gap-6 px-4 w-full max-w-lg mx-auto">
@@ -142,6 +250,28 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
               {completedChildren} of {task.children.length} sub-tasks done
             </span>
           )}
+        </div>
+
+        {/* Size picker (keys 1/2/3) */}
+        <div className="flex items-center gap-1.5 text-xs">
+          <span className="text-text-muted">Size</span>
+          {(["s", "m", "l"] as const).map((s, i) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => setSize(s)}
+              aria-pressed={size === s}
+              title={`${s === "s" ? "Small · under 30 min" : s === "m" ? "Medium · about an hour" : "Large · half a day"} (press ${i + 1})`}
+              className={cn(
+                "font-mono uppercase h-6 w-6 rounded border flex items-center justify-center transition-all",
+                size === s
+                  ? "border-accent-blue/50 bg-accent-blue/10 text-accent-blue"
+                  : "border-border text-text-muted hover:border-text-muted",
+              )}
+            >
+              {s}
+            </button>
+          ))}
         </div>
 
         {/* Note indicator + expand/edit */}
@@ -260,6 +390,7 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
       <div className="grid grid-cols-4 gap-2 w-full">
         <ActionButton
           label={isWinddown ? "Tomorrow" : "Today"}
+          keyHint="T"
           hint={showHints ? (isWinddown ? "first thing" : "do it today") : undefined}
           onClick={() => handleAction("confirm")}
           loading={loading}
@@ -267,6 +398,7 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
         />
         <ActionButton
           label="Soon"
+          keyHint="S"
           hint={showHints ? "this week" : undefined}
           onClick={() => handleAction("defer", "soon")}
           loading={loading}
@@ -274,6 +406,7 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
         />
         <ActionButton
           label="Later"
+          keyHint="L"
           hint={showHints ? "not now" : undefined}
           onClick={() => handleAction("defer", "later")}
           loading={loading}
@@ -281,6 +414,7 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
         />
         <ActionButton
           label="Someday"
+          keyHint="O"
           hint={showHints ? "be honest" : undefined}
           onClick={() => handleAction("defer", "someday")}
           loading={loading}
@@ -292,6 +426,7 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
       <div className="grid grid-cols-2 gap-2 w-full">
         <ActionButton
           label="Done"
+          keyHint="D"
           hint={showHints ? "already handled" : undefined}
           onClick={() => handleAction("complete")}
           loading={loading}
@@ -299,24 +434,38 @@ export function TriageCard({ task, progress, onAction, showHints = false, isWind
         />
         <ActionButton
           label="Let go"
+          keyHint="X"
           hint={showHints ? "release it" : undefined}
           onClick={() => handleAction("kill")}
           loading={loading}
           className="bg-bg-surface text-accent-red/70 hover:bg-accent-red/10"
         />
       </div>
+
+      {/* Undo affordance */}
+      {onUndo && (
+        <button
+          onClick={onUndo}
+          disabled={!canUndo || loading}
+          className="text-xs text-text-muted hover:text-text-secondary transition-colors disabled:opacity-40 min-h-[44px] px-4"
+        >
+          Undo last <kbd className="font-mono">Z</kbd>
+        </button>
+      )}
     </div>
   );
 }
 
 function ActionButton({
   label,
+  keyHint,
   hint,
   onClick,
   loading,
   className,
 }: {
   label: string;
+  keyHint?: string;
   hint?: string;
   onClick: () => void;
   loading: boolean;
@@ -327,10 +476,13 @@ function ActionButton({
       onClick={onClick}
       disabled={loading}
       className={cn(
-        "flex flex-col items-center justify-center gap-0.5 rounded-xl min-h-[44px] py-3 px-2 transition-colors disabled:opacity-50",
+        "relative flex flex-col items-center justify-center gap-0.5 rounded-xl min-h-[44px] py-3 px-2 transition-colors disabled:opacity-50",
         className,
       )}
     >
+      {keyHint && (
+        <kbd className="absolute top-1 right-1.5 font-mono text-[9px] opacity-50">{keyHint}</kbd>
+      )}
       <span className="text-sm font-medium">{label}</span>
       {hint && <span className="text-[10px] opacity-60">{hint}</span>}
     </button>

--- a/frontend/src/components/triage-flow.tsx
+++ b/frontend/src/components/triage-flow.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { BriefingResponse, MITSuggestion, Task, TriageQueue } from "@/lib/api-types";
-import { getTriageQueue, getMe, getTriageBriefing, createCheckout, getMITSuggestion, setMIT, getTasks } from "@/lib/api";
+import type {
+  BriefingResponse,
+  BucketType,
+  MITSuggestion,
+  Task,
+  TriageAction,
+  TriageQueue,
+} from "@/lib/api-types";
+import { getTriageQueue, getMe, getTriageBriefing, createCheckout, getMITSuggestion, setMIT, getTasks, updateTask } from "@/lib/api";
 import { TriageCard } from "@/components/triage-card";
 import { ProBadge } from "@/components/pro-badge";
 import { MITSelection } from "@/components/mit-selection";
@@ -31,6 +38,11 @@ export function TriageFlow({ onComplete, initialQueue }: TriageFlowProps) {
   const [todayTasks, setTodayTasks] = useState<Task[]>([]);
   const [showQuote, setShowQuote] = useState(false);
   const todayQuote = getTodayQuote();
+
+  // Undo stack: each entry captures what a card action changed so `z` can revert
+  // it. prevBucket restores defers/confirms; complete/kill are reopened to pending.
+  type UndoEntry = { index: number; taskId: string; action: TriageAction; prevBucket: BucketType };
+  const [undoStack, setUndoStack] = useState<UndoEntry[]>([]);
 
   useEffect(() => {
     const queuePromise = initialQueue
@@ -97,12 +109,45 @@ export function TriageFlow({ onComplete, initialQueue }: TriageFlowProps) {
     else onComplete();
   }
 
-  function handleAction(result: { triage_complete: boolean; remaining: number }) {
-    if (result.triage_complete || result.remaining === 0 || !queue || currentIndex >= queue.tasks.length - 1) {
+  function handleAction(result: { action: TriageAction; triage_complete: boolean; remaining: number }) {
+    // Record for undo, using the card's current task (still at currentIndex).
+    if (queue) {
+      const acted = queue.tasks[currentIndex];
+      if (acted) {
+        setUndoStack((s) => [
+          ...s,
+          {
+            index: currentIndex,
+            taskId: acted.id,
+            action: result.action,
+            prevBucket: acted.bucket,
+          },
+        ]);
+      }
+    }
+    // Walk the queue by index (works for both real and synthesized results).
+    if (!queue || currentIndex >= queue.tasks.length - 1) {
       handleTriageFinished();
       return;
     }
     setCurrentIndex((i) => i + 1);
+  }
+
+  async function handleUndo() {
+    const last = undoStack[undoStack.length - 1];
+    if (!last) return;
+    setUndoStack((s) => s.slice(0, -1));
+    setCurrentIndex(last.index);
+    try {
+      if (last.action === "confirm" || last.action === "defer") {
+        await updateTask(last.taskId, { bucket: last.prevBucket });
+      } else {
+        // complete (reopen) or kill (un-archive) → back to pending.
+        await updateTask(last.taskId, { status: "pending" });
+      }
+    } catch (err) {
+      console.error("Undo failed:", err);
+    }
   }
 
   async function handleMITConfirm(taskId: string) {
@@ -318,6 +363,8 @@ export function TriageFlow({ onComplete, initialQueue }: TriageFlowProps) {
         progress={{ current: currentIndex + 1, total: queue.tasks.length }}
         onAction={handleAction}
         showHints={showHints}
+        onUndo={handleUndo}
+        canUndo={undoStack.length > 0}
       />
       {skipLink}
     </div>

--- a/frontend/src/components/winddown-modal.tsx
+++ b/frontend/src/components/winddown-modal.tsx
@@ -117,6 +117,11 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
   // --- Intro: reflection before cards ---
   if (phase === "intro") {
     const remaining = tasks.length;
+    // Honest, non-numerical distinction from placement data:
+    //  - had a block but didn't finish → the plan was off (block too small / eaten)
+    //  - never got a block → you said "today" but never made room for it
+    const placedUnfinished = tasks.filter((t) => t.placement).length;
+    const neverPlaced = tasks.filter((t) => !t.placement).length;
 
     return (
       <RitualOverlay>
@@ -136,6 +141,16 @@ export function WinddownModal({ onComplete }: WinddownModalProps) {
             {remaining > 0 && (
               <p className="text-sm text-text-muted">
                 {remaining} task{remaining !== 1 ? "s" : ""} still open &mdash; where should {remaining === 1 ? "it" : "they"} go?
+              </p>
+            )}
+            {placedUnfinished > 0 && (
+              <p className="text-sm text-text-secondary">
+                {placedUnfinished} had time blocked but didn&apos;t get done. Was the plan off?
+              </p>
+            )}
+            {neverPlaced > 0 && placedUnfinished > 0 && (
+              <p className="text-sm text-text-secondary">
+                {neverPlaced} never got a block &mdash; you said today but never made room.
               </p>
             )}
           </div>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -2,6 +2,15 @@
 export type BucketType = "today" | "soon" | "later" | "someday";
 export type TaskStatus = "pending" | "complete" | "archived";
 export type TriageAction = "confirm" | "defer" | "complete" | "kill";
+// Coarse task size: s = under 30 min, m = ~an hour, l = half a day.
+export type TaskSize = "s" | "m" | "l";
+
+// Today's time-block placement, as reported by Plot.
+export interface Placement {
+  block_start: string | null;
+  block_type: string | null;
+  calendar_event_id: string | null;
+}
 
 // Domain
 export interface Domain {
@@ -45,6 +54,8 @@ export interface Task {
   is_mit: boolean;
   important: boolean;
   urgent: boolean;
+  size: TaskSize | null;
+  placement: Placement | null;
 }
 
 // MIT suggestion from the backend
@@ -120,4 +131,17 @@ export interface PortalResponse {
 export interface BillingStatus {
   subscription_status: "free" | "active" | "past_due" | "canceled";
   is_pro: boolean;
+}
+
+// Personal access tokens
+export interface ApiToken {
+  id: string;
+  name: string;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+// Returned once, at creation, with the raw token to copy.
+export interface ApiTokenCreated extends ApiToken {
+  token: string;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,6 @@
 import type {
+  ApiToken,
+  ApiTokenCreated,
   AppState,
   BillingStatus,
   BriefingResponse,
@@ -9,6 +11,7 @@ import type {
   MITSuggestion,
   PortalResponse,
   Task,
+  TaskSize,
   TaskStatus,
   TriageAction,
   TriageQueue,
@@ -69,13 +72,21 @@ export async function createTask(body: {
   skip_triage_stamp?: boolean;
   important?: boolean;
   urgent?: boolean;
+  size?: TaskSize;
 }): Promise<Task> {
   return request<Task>("tasks", { method: "POST", body: JSON.stringify(body) });
 }
 
 export async function updateTask(
   id: string,
-  body: { text?: string; bucket?: BucketType; domain_id?: string | null; status?: TaskStatus; notes?: string | null },
+  body: {
+    text?: string;
+    bucket?: BucketType;
+    domain_id?: string | null;
+    status?: TaskStatus;
+    notes?: string | null;
+    size?: TaskSize;
+  },
 ): Promise<Task> {
   return request<Task>(`tasks/${id}`, { method: "PATCH", body: JSON.stringify(body) });
 }
@@ -196,5 +207,20 @@ export async function getBillingStatus(): Promise<BillingStatus> {
   return request<BillingStatus>("billing/status");
 }
 
+// Personal access tokens
+export async function getApiTokens(): Promise<ApiToken[]> {
+  return request<ApiToken[]>("api-tokens");
+}
+
+export async function createApiToken(name: string): Promise<ApiTokenCreated> {
+  return request<ApiTokenCreated>("api-tokens", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function deleteApiToken(id: string): Promise<void> {
+  return request<void>(`api-tokens/${id}`, { method: "DELETE" });
+}
 
 export { ApiError };

--- a/frontend/src/lib/parse-capture.ts
+++ b/frontend/src/lib/parse-capture.ts
@@ -1,0 +1,91 @@
+import type { BucketType, Domain, TaskSize } from "./api-types";
+
+export interface ParsedCapture {
+  text: string;
+  domainId?: string;
+  important: boolean;
+  urgent: boolean;
+  bucket?: BucketType;
+  size?: TaskSize;
+}
+
+const BUCKET_WORDS: Record<string, BucketType> = {
+  today: "today",
+  soon: "soon",
+  later: "later",
+  someday: "someday",
+};
+
+const SIZE_LETTERS: Record<string, TaskSize> = { s: "s", m: "m", l: "l" };
+
+/**
+ * Parse inline capture tokens out of a task string. The grammar lets capture be
+ * fast with *optional* classification (Tend's real sorting moment is triage):
+ *
+ *   #health         domain, prefix-matched against the user's domain names
+ *   !               important
+ *   !!              important + urgent
+ *   u!              urgent
+ *   >soon|later|someday|today   bucket
+ *   ~s|~m|~l        size (S/M/L)
+ *
+ * Recognized tokens are stripped from the returned text. Unrecognized tokens
+ * (e.g. a `#tag` that matches no domain) are left in the text verbatim.
+ */
+export function parseCapture(raw: string, domains: Domain[]): ParsedCapture {
+  const result: ParsedCapture = { text: "", important: false, urgent: false };
+  const kept: string[] = [];
+
+  for (const token of raw.split(/\s+/)) {
+    if (token === "") continue;
+    const lower = token.toLowerCase();
+
+    // Priority
+    if (token === "!") {
+      result.important = true;
+      continue;
+    }
+    if (token === "!!") {
+      result.important = true;
+      result.urgent = true;
+      continue;
+    }
+    if (token === "u!" || token === "!u") {
+      result.urgent = true;
+      continue;
+    }
+
+    // Bucket: >later
+    if (token.startsWith(">")) {
+      const bucket = BUCKET_WORDS[lower.slice(1)];
+      if (bucket) {
+        result.bucket = bucket;
+        continue;
+      }
+    }
+
+    // Size: ~m
+    if (token.startsWith("~") && token.length === 2) {
+      const size = SIZE_LETTERS[lower.slice(1)];
+      if (size) {
+        result.size = size;
+        continue;
+      }
+    }
+
+    // Domain: #health (prefix match, first wins). Only bind once.
+    if (token.startsWith("#") && token.length > 1 && result.domainId === undefined) {
+      const query = lower.slice(1);
+      const match = domains.find((d) => d.name.toLowerCase().startsWith(query));
+      if (match) {
+        result.domainId = match.id;
+        continue;
+      }
+    }
+
+    kept.push(token);
+  }
+
+  result.text = kept.join(" ").trim();
+  return result;
+}


### PR DESCRIPTION
Implements all six issues from the Tend × Plot integration exploration (#212–#217) on one branch.

## What's in here

### #212 — Personal access tokens + scoped public API (the keystone)
- `api_tokens` table storing only a SHA-256 hash; raw `tend_pat_...` shown once at creation.
- `get_user_id_allow_pat` dependency accepts a PAT **or** the proxy JWT. **Scoping = which routes opt in** (no per-path allowlist): `GET/POST /tasks`, `complete`, `mit`, `GET /triage`, `POST /placements`.
- `/api-tokens` CRUD + a "Personal access tokens" Settings section (create / copy-once / revoke).
- Plot can stop copying `INTERNAL_JWT_SECRET`; Shortcuts/Raycast/Watch can capture in one call.

### #213 — One-Enter capture with a token grammar
- Single Enter submits and refocuses (rapid-fire; input never disabled). Tab opens the domain/priority picker.
- `parse-capture.ts`: `#domain` `!` `!!` `u!` `>bucket` `~size`, stripped from text; unknown `#tags` kept.

### #214 — Keyboard-driven triage with undo
- Keys `t/s/l/o/d/x/n/r/1/2/3` and `z` (undo). Key hints on buttons; untriaged count on the rail all day.
- "Let go" is a reversible **soft-archive**; backend allows `complete→pending` reopen so "Done" is undoable too.

### #215 — Triage → time-block loop (Tend side)
- `task_placements` (upsert on task+date), `POST /tasks/{id}/placements` (PAT-scoped).
- `GET /triage` already exposes `triage_complete` for Plot. Placement badge on task rows; wind-down surfaces placed-but-unfinished vs never-placed honesty.

### #216 — Task size (S/M/L)
- `SizeType` enum + nullable column; `~s/~m/~l` capture token, `1/2/3` triage keys, card glyph, exposed in `GET /tasks`.

### #217 — Mobile capture via PWA share target
- `manifest.ts` with `share_target`, no-op service worker (installability only, no offline sync), authenticated `/capture` page reusing the token grammar.

## Verification
- Backend: **202 tests pass** (26 new across `test_api_tokens`, `test_placements`, `test_size`, updated transition test), ruff clean, migrations apply + reverse cleanly.
- Frontend: `tsc` clean, eslint clean, `next build` succeeds. `mise run check` green across both halves.

## Notes / decisions worth a look
- **Scoping mechanism** (#212): opt-in dependency rather than an allowlist — simple, but means "expose to PAT" is a one-line dependency swap. Deliberate.
- **"Let go" now soft-archives** instead of hard-deleting (sanctioned by #214: "soft-delete behind the scenes"). Nothing is lost — archived tasks are recoverable on Someday. The hard-delete `kill` triage endpoint still exists; the card just no longer uses it.
- **Today placed/unplaced divider** (#215): implemented the placement **badge** but not a literal list divider, since partitioning the list fights the sacred position-based DnD ordering. The honesty distinction lands in wind-down (not DnD-ordered) instead. Easy follow-up if a divider is wanted.
- Plot-side work (notifications, composer capacity) is tracked in Plot's repo; this PR is the Tend side of #215/#216.

Closes #212, #213, #214, #215, #216, #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)