### PR TITLE
Make the PAT surface usable end to end, and add a tend CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,25 @@ jobs:
         working-directory: backend
         run: ruff format --check .
 
+      # The CLI is a separate package with no database dependency, so unlike the
+      # backend suite its tests can actually run here. They pin the capture
+      # grammar against the frontend parser it was ported from.
+      - name: Install CLI
+        working-directory: cli
+        run: pip install -e . --quiet
+
+      - name: Ruff lint (CLI)
+        working-directory: cli
+        run: ruff check .
+
+      - name: Ruff format check (CLI)
+        working-directory: cli
+        run: ruff format --check .
+
+      - name: CLI tests
+        working-directory: cli
+        run: pytest -q
+
       - name: Install frontend dependencies
         working-directory: frontend
         run: pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ src-tauri/target/
 
 # Python
 backend/.venv/
+cli/.venv/
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,10 @@ The main `[...proxy]` catch-all requires a NextAuth session. Endpoints that must
 External clients (Plot, Raycast, iOS Shortcuts) authenticate with a `tend_pat_...` token instead of the 60s proxy JWT. Design:
 - `api_tokens` table stores only a **SHA-256 hash** of the raw token (fast, unsalted — auth looks a token up by hash without knowing the user). The raw value is shown **once** at creation.
 - `core/security.py` has two dependencies: `get_current_user_id` (proxy-JWT only, the default for every route) and `get_user_id_allow_pat` (accepts a PAT **or** the proxy JWT).
-- **Scoping is expressed by which routes use `get_user_id_allow_pat`** — there is no per-path allowlist. A PAT works only on the endpoints that opted in (currently `GET/POST /tasks`, `POST /tasks/{id}/complete`, `POST /tasks/{id}/mit`, `GET /triage`, `POST /tasks/{id}/placements`). To expose a new endpoint to PATs, switch its dependency; to keep it internal, leave `get_current_user_id`.
+- **Scoping is expressed by which routes use `get_user_id_allow_pat`** — there is no per-path allowlist. To expose a new endpoint to PATs, switch its dependency; to keep it internal, leave `get_current_user_id`.
+- **The policy: a PAT can create, read, and modify; it cannot destroy.** A token sits in plaintext in config files and agent settings, so it is a more exposed credential than a browser session — `DELETE /tasks/{id}`, `DELETE /domains/{id}`, everything under `/me` and `/billing`, and **all of `/api-tokens`** (a PAT must never mint or revoke PATs) stay proxy-JWT only. Everything reversible is deliberately open, because per PRD §17.2 the question of *whether* to act belongs in the agent's prompt, not in the API.
+- **The policy lives as data in `PAT_MATRIX` (`tests/test_api_tokens.py`)**, which parametrizes a test asserting the 401 boundary route by route. Add a route → add a row. This is what stops a new endpoint from silently shipping UI-only, which is exactly how the surface drifted after #218.
+- **The proxy is the only door.** The backend has no public domain, so an external client reaches it through `frontend/src/app/api/[...proxy]/route.ts`, which forwards `Bearer tend_pat_*` verbatim and mints a fresh 60s JWT for session callers. **Only that prefix is passed through** — any other Authorization value is discarded and replaced, so a caller can never supply its own proxy token. Before #219 the proxy rejected every session-less request, which meant the PATs shipped in #218 were unreachable in production.
 - **Test gotcha:** `conftest.py` must override *both* auth dependencies. To test real PAT auth/scoping, pop the overrides in a fixture (see `TestPatScoping` in `test_api_tokens.py`).
 
 ### Task Placements — Tend records, never schedules
@@ -82,6 +85,11 @@ External clients (Plot, Raycast, iOS Shortcuts) authenticate with a `tend_pat_..
 
 ### Status transitions: complete→pending is a "reopen"
 `update_task` allows `pending↔archived` **and** `complete→pending` (clears `completed_at`). The reopen exists so keyboard-triage undo can revert a "Done". `complete→archived` is still invalid.
+
+### Triage `kill` archives; it does not delete
+`POST /triage/{id}` is uniformly reversible. `kill` ("let go") calls `task_service.archive_task`, which soft-archives the task and cascade-archives its pending children, mirroring `complete_task`'s shape. Hard delete lives only at `DELETE /tasks/{id}`, which is session-only.
+
+This closed a divergence rather than adding a mechanism: `triage-card.tsx` already intercepted "let go" client-side and PATCHed `status=archived` so undo could restore it, which left the backend's hard-delete branch reachable only by direct API callers. Aligning the backend meant the whole endpoint could be handed to PATs with no auth-mode plumbing.
 
 ## Project Structure
 
@@ -106,15 +114,18 @@ tend/
 │   │   ├── schemas/    # request/response Pydantic models
 │   │   └── services/   # task_service, triage_service, domain_service, stats_service, composter_service
 │   ├── alembic/        # migrations (date-prefixed filenames)
-│   ├── tests/          # 75 tests, shared DB with rollback per test
+│   ├── tests/          # 229 tests, shared DB with rollback per test
 │   ├── start.py        # Railway startup: validate env, run migrations, start uvicorn
 │   └── railway.toml
+├── cli/                # `tend` CLI (uv tool install ./cli) — not deployed
+│   ├── tend_cli/       # cli.py (commands), client.py (HTTP + token), grammar.py
+│   └── tests/          # grammar parity with the frontend parser, ref resolution
 ├── docs/               # PRD, plans, playground, solutions/learnings
 │   └── log/            # Build-in-public learning journal (numbered entries)
-├── src/                # (prototype — reference only)
-├── src-tauri/          # (prototype — reference only)
 └── CLAUDE.md           # this file
 ```
+
+(The Tauri prototype that used to live in `src/` and `src-tauri/` was removed in 2f4048e.)
 
 ## Build Phases
 
@@ -152,6 +163,27 @@ Notes:
 - **uv owns the Python venv, not mise** — mise's `python = "3.13"` pin matches `.python-version`,
   but `uv run` reuses an existing `.venv`. `rm -rf backend/.venv && uv sync` rebuilds on 3.13.
 - **CI gotcha:** never pipe `mise run check` through `tail` — it masks mise's exit code.
+
+## The `tend` CLI
+
+`cli/` is a third Python package (its own `pyproject.toml` and `.venv`, `uv tool install ./cli`),
+independent of the backend and never deployed. It talks to the API over HTTP with a PAT, so it is
+just another client — it imports nothing from `backend/`.
+
+- **It is the agent integration surface.** An MCP server was considered and deliberately deferred:
+  MCP is a wrapper over an API that already exists, and a CLI reaches every agent harness, cron
+  job, and shell script without one. MCP earns its keep only for clients with no shell (Claude
+  Desktop, mobile), and by then it is a thin wrapper over the same client. Read commands take
+  `--json` so one artifact serves both a human and an agent.
+- **`grammar.py` is a line-by-line port of `frontend/src/lib/parse-capture.ts`**, with
+  `tests/test_grammar.py` mirroring the frontend's cases. Parsing is client-side in both, matching
+  the browser — it is an input affordance, not a security boundary, since the API validates what
+  it produces regardless. **Change the grammar on one side, change it on both.**
+- **`tend add` defaults to the `soon` bucket, not `today`.** Deciding something belongs in today is
+  what triage is for; a terminal capture shouldn't quietly add to a day already committed to.
+- Interactive `tend triage` mirrors the web app's keys (`t/s/l/o/d/x`) and refuses to run without a
+  TTY, so an agent that runs it bare gets an error instead of a hang.
+- Tests: `cd cli && uv run pytest` (not part of `mise run check` yet).
 
 ## Conventions
 

--- a/backend/app/api/domains.py
+++ b/backend/app/api/domains.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from sqlmodel import Session, select
 
 from app.core.deps import get_db
-from app.core.security import get_current_user_id
+from app.core.security import get_current_user_id, get_user_id_allow_pat
 from app.models.user import User
 from app.schemas.domain_schemas import DomainCreate, DomainResponse, DomainUpdate
 from app.services import domain_service
@@ -24,7 +24,7 @@ def _to_response(domain) -> DomainResponse:
 @router.get("", response_model=list[DomainResponse])
 def list_domains(
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     domains = domain_service.get_domains(db, user_id)
     return [_to_response(d) for d in domains]
@@ -34,7 +34,7 @@ def list_domains(
 def create_domain(
     body: DomainCreate,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     user = db.exec(select(User).where(User.id == user_id)).one()
     is_pro = user.subscription_status in ("active", "past_due")
@@ -49,7 +49,7 @@ def update_domain(
     domain_id: uuid.UUID,
     body: DomainUpdate,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     domain = domain_service.update_domain(
         db,

--- a/backend/app/api/state.py
+++ b/backend/app/api/state.py
@@ -7,7 +7,7 @@ from sqlalchemy import select as sa_select
 from sqlmodel import Session
 
 from app.core.deps import get_db
-from app.core.security import get_current_user_id
+from app.core.security import get_user_id_allow_pat
 from app.models.enums import BucketType, TaskStatus
 from app.models.task import Task
 
@@ -37,7 +37,7 @@ class StateResponse(BaseModel):
 @router.get("", response_model=StateResponse)
 def get_state(
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     # Priority counts via GROUP BY
     priority_rows = db.exec(

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -77,7 +77,7 @@ def list_tasks(
 def get_task(
     task_id: uuid.UUID,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     task = task_service.get_task(db, user_id, task_id)
     return _to_response(task)
@@ -120,7 +120,7 @@ def create_task(
 def reorder_tasks(
     body: ReorderRequest,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     count = task_service.reorder_tasks(db, user_id, body.task_ids, body.bucket)
     return {"updated": count}
@@ -131,7 +131,7 @@ def update_task(
     task_id: uuid.UUID,
     body: TaskUpdate,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     kwargs: dict = {}
     if body.text is not None:
@@ -159,7 +159,7 @@ def set_priority(
     task_id: uuid.UUID,
     body: PriorityUpdate,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     kwargs: dict = {}
     if body.important is not None:

--- a/backend/app/api/triage.py
+++ b/backend/app/api/triage.py
@@ -7,7 +7,7 @@ from sqlmodel import Session, select
 from app.api.tasks import _to_response
 from app.core.deps import get_db
 from app.core.errors import AppError
-from app.core.security import get_current_user_id, get_user_id_allow_pat
+from app.core.security import get_user_id_allow_pat
 from app.models.enums import BucketType, TaskStatus
 from app.models.task import Task
 from app.models.user import User
@@ -60,7 +60,7 @@ def get_triage_queue(
 @router.get("/briefing", response_model=BriefingResponse)
 def get_briefing(
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     user = db.get(User, user_id)
     is_pro = user.subscription_status in ("active", "past_due")
@@ -83,7 +83,7 @@ def get_briefing(
 @router.get("/mit-suggestion", response_model=MITSuggestionResponse | None)
 def get_mit_suggestion(
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     tasks = db.exec(
         select(Task).where(
@@ -104,7 +104,7 @@ def triage_task(
     task_id: uuid.UUID,
     body: TriageRequest,
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     result = triage_service.triage_task(
         db,
@@ -120,7 +120,7 @@ def triage_task(
 @router.get("/winddown", response_model=WinddownResponse)
 def get_winddown(
     db: Session = Depends(get_db),
-    user_id: uuid.UUID = Depends(get_current_user_id),
+    user_id: uuid.UUID = Depends(get_user_id_allow_pat),
 ):
     from datetime import date
 

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -283,6 +283,40 @@ def complete_task(db: Session, user_id: uuid.UUID, task_id: uuid.UUID) -> Task:
     return task
 
 
+def archive_task(db: Session, user_id: uuid.UUID, task_id: uuid.UUID) -> Task:
+    """Soft-archive a task and its pending children ("let go").
+
+    Mirrors complete_task's cascade. Reversible via PATCH status=pending, which
+    is why triage's "kill" action archives instead of hard-deleting; delete_task
+    remains the irreversible path behind DELETE /tasks/{id}.
+    """
+    task = get_task(db, user_id, task_id)
+    now = datetime.utcnow()
+
+    if task.status != TaskStatus.pending:
+        raise AppError(
+            code="invalid_status_transition",
+            message=f"Cannot transition from {task.status.value} to archived",
+            status_code=422,
+        )
+
+    task.status = TaskStatus.archived
+    task.updated_at = now
+    db.add(task)
+
+    children = list(
+        db.exec(select(Task).where(Task.parent_id == task_id, Task.status == TaskStatus.pending))
+    )
+    for child in children:
+        child.status = TaskStatus.archived
+        child.updated_at = now
+        db.add(child)
+
+    db.flush()
+    db.refresh(task)
+    return task
+
+
 def reorder_tasks(
     db: Session, user_id: uuid.UUID, task_ids: list[uuid.UUID], bucket: BucketType
 ) -> int:

--- a/backend/app/services/triage_service.py
+++ b/backend/app/services/triage_service.py
@@ -96,7 +96,14 @@ def triage_task(
         task_service.complete_task(db, user_id, task_id)
 
     elif action == "kill":
-        task_service.delete_task(db, user_id, task_id)
+        # "Let go" is a reversible soft-archive, not a hard delete. The frontend
+        # has always treated it that way (triage-card intercepts kill and PATCHes
+        # status=archived) so undo can restore it; the backend now matches. Hard
+        # delete stays at DELETE /tasks/{id}, which is session-only.
+        task.triaged_at = today
+        db.add(task)
+        db.flush()
+        task_service.archive_task(db, user_id, task_id)
 
     # Check if triage is now complete
     remaining_count = db.exec(

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -11,6 +11,53 @@ from app.main import app
 from app.models.user import User
 from app.services import api_token_service
 
+# An id that will never exist, so routes 404 rather than mutating real rows.
+_MISSING = "00000000-0000-0000-0000-0000000000ff"
+
+# The PAT policy, as data: a token can create, read, and modify; it cannot
+# destroy. A PAT sits in plaintext in config files and agent settings, so it is
+# a more exposed credential than a browser session — irreversible operations and
+# anything account-level stay behind the short-lived proxy JWT. Per PRD §17.2 the
+# question of *whether* to act belongs in the agent's prompt, not the API, so
+# everything reversible is deliberately open.
+#
+# `pat_allowed` asserts only that the auth gate let the request through. A route
+# may still answer 404 or 422 for a placeholder id; that is not what this pins.
+PAT_MATRIX = [
+    # Read.
+    ("GET", "/state", None, True),
+    ("GET", "/tasks", None, True),
+    ("GET", f"/tasks/{_MISSING}", None, True),
+    ("GET", "/triage", None, True),
+    ("GET", "/triage/winddown", None, True),
+    ("GET", "/triage/briefing", None, True),
+    ("GET", "/triage/mit-suggestion", None, True),
+    ("GET", "/domains", None, True),
+    # Create.
+    ("POST", "/tasks", {"text": "from an agent", "bucket": "today"}, True),
+    ("POST", "/domains", {"name": "Agent", "color": "#3b82f6"}, True),
+    # Modify.
+    ("PATCH", f"/tasks/{_MISSING}", {"text": "renamed"}, True),
+    ("PATCH", "/tasks/reorder", {"task_ids": [], "bucket": "today"}, True),
+    ("POST", f"/tasks/{_MISSING}/priority", {"important": True}, True),
+    ("POST", f"/tasks/{_MISSING}/complete", None, True),
+    ("POST", f"/tasks/{_MISSING}/mit", None, True),
+    ("POST", f"/triage/{_MISSING}", {"action": "confirm"}, True),
+    ("PATCH", f"/domains/{_MISSING}", {"name": "Renamed"}, True),
+    # Destroy — session only. Domain delete also orphans tasks.
+    ("DELETE", f"/tasks/{_MISSING}", None, False),
+    ("DELETE", f"/domains/{_MISSING}", None, False),
+    # Account level — session only.
+    ("GET", "/me", None, False),
+    ("PATCH", "/me", {"default_layout": "list"}, False),
+    ("DELETE", "/me", None, False),
+    ("GET", "/billing/status", None, False),
+    # Token management — a PAT must never mint or revoke PATs.
+    ("GET", "/api-tokens", None, False),
+    ("POST", "/api-tokens", {"name": "escalated"}, False),
+    ("DELETE", f"/api-tokens/{_MISSING}", None, False),
+]
+
 
 class TestApiTokenService:
     def test_create_returns_raw_token_once(self, db: Session, test_user: User):
@@ -118,3 +165,14 @@ class TestPatScoping:
         api_token_service.revoke_token(db, test_user.id, token.id)
         r = real_auth_client.get("/tasks", headers={"Authorization": f"Bearer {raw}"})
         assert r.status_code == 401
+
+    @pytest.mark.parametrize(("method", "path", "body", "pat_allowed"), PAT_MATRIX)
+    def test_pat_matrix(self, real_auth_client, db, test_user, method, path, body, pat_allowed):
+        _, raw = api_token_service.create_token(db, test_user.id, "matrix")
+        r = real_auth_client.request(
+            method, path, json=body, headers={"Authorization": f"Bearer {raw}"}
+        )
+        if pat_allowed:
+            assert r.status_code != 401, f"{method} {path} should accept a PAT"
+        else:
+            assert r.status_code == 401, f"{method} {path} must reject a PAT"

--- a/backend/tests/test_triage.py
+++ b/backend/tests/test_triage.py
@@ -56,9 +56,19 @@ class TestTriageFlow:
         r = client.post(f"/triage/{task.id}", json={"action": "kill"})
         assert r.status_code == 200
         assert r.json()["action"] == "kill"
+        assert client.get(f"/tasks/{task.id}").json()["status"] == "archived"
+
+    def test_triage_kill_is_reversible(self, client, test_user, test_tasks):
+        """Kill archives rather than deletes, so undo can restore the task."""
+        task = test_tasks[0]
+        client.post(f"/triage/{task.id}", json={"action": "kill"})
+
+        r = client.patch(f"/tasks/{task.id}", json={"status": "pending"})
+        assert r.status_code == 200
+        assert r.json()["status"] == "pending"
 
     def test_triage_kill_task_with_children(self, client, test_user, test_tasks, db):
-        """Kill a parent task — children should be cascade-deleted too."""
+        """Kill a parent task — children should be cascade-archived too."""
         parent = test_tasks[0]
         child = Task(
             user_id=test_user.id,
@@ -75,13 +85,15 @@ class TestTriageFlow:
         assert r.status_code == 200
         assert r.json()["action"] == "kill"
 
-        # Parent gone
+        # Parent archived, not deleted — "let go" stays recoverable
         r2 = client.get(f"/tasks/{parent.id}")
-        assert r2.status_code == 404
+        assert r2.status_code == 200
+        assert r2.json()["status"] == "archived"
 
-        # Child cascade-deleted
+        # Child cascade-archived
         r3 = client.get(f"/tasks/{child_id}")
-        assert r3.status_code == 404
+        assert r3.status_code == 200
+        assert r3.json()["status"] == "archived"
 
     def test_triage_kill_decrements_remaining(self, client, test_user, test_tasks):
         """Kill should decrement the remaining count."""

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,97 @@
+# tend — command-line client
+
+One binary for two callers. A human types `tend add "call the dentist #health"`; an agent runs
+the same command through a shell and passes `--json` to read structured output back. There is no
+separate machine interface because there doesn't need to be one — a CLI works anywhere a shell
+does, which includes every agent harness, cron, and shell script.
+
+## Install
+
+```bash
+uv tool install ./cli          # from the repo root
+# or, for development
+cd cli && uv sync && uv run tend --help
+```
+
+## Auth
+
+Create a token in Tend under **Settings → API tokens**, then:
+
+```bash
+tend login                            # stores it in ~/.config/tend/config.json (chmod 600)
+export TEND_TOKEN=tend_pat_...        # or just set it for this shell
+export TEND_API_URL=http://localhost:8000   # point at a local backend
+```
+
+Tokens **can** create, read, and modify. They **cannot** delete tasks or domains, change account
+settings, or mint more tokens — those need a browser session. A token sits in plaintext in config
+files and agent settings, so anything irreversible stays behind the session. The full policy is
+data, in `backend/tests/test_api_tokens.py`.
+
+## Commands
+
+```bash
+tend add "file the appellate brief #work !! ~s"   # capture
+tend ls [-b today] [-d work] [-s archived]        # list
+tend done <ref>                                   # complete
+tend triage                                       # walk the queue interactively
+tend triage --list                                # read the queue without acting
+tend triage <ref> defer --bucket later            # one decision, no prompting
+tend state                                        # counts by bucket and priority
+tend domains
+```
+
+`<ref>` is a task id, an id prefix (`a3f2`), or a unique text substring (`dentist`). Ambiguity is
+always an error listing the candidates, never a guess.
+
+Every read command takes `--json`.
+
+## Capture grammar
+
+The same inline tokens the web app understands, parsed client-side by `grammar.py`:
+
+| Token | Effect |
+| --- | --- |
+| `#health` | domain, prefix-matched against your domain names |
+| `!` | important |
+| `!!` | important + urgent |
+| `u!` or `!u` | urgent |
+| `>today` `>soon` `>later` `>someday` | bucket |
+| `~s` `~m` `~l` | size |
+
+Unrecognized tokens are left in the text verbatim, so `renew the domain #nonsense` stays intact.
+
+Parsing is client-side, matching the browser. It's an input affordance, not a security boundary —
+whatever it produces still goes through the API's own validation. `grammar.py` is a deliberate
+line-by-line port of `frontend/src/lib/parse-capture.ts`, and `tests/test_grammar.py` mirrors the
+frontend's cases so the two can't quietly diverge. **Change one, change both.**
+
+## Why `add` defaults to `soon`
+
+Deciding something belongs in *today* is what triage is for. A capture typed into a terminal
+shouldn't quietly add to a day you already committed to, so `tend add` lands in `soon` and waits
+for tomorrow's triage. Say `-b today` or `>today` when you actually mean it.
+
+(Note that a task captured today won't appear in *today's* triage queue either way — creation
+stamps `triaged_at`, so it surfaces tomorrow. That's the app's design, not the CLI's.)
+
+## Interactive triage
+
+`tend triage` walks the queue with the same keys as the web app's keyboard triage, so there's one
+set of muscle memory:
+
+```
+t = today    s = soon    l = later    o = someday    d = done    x = let go    q = quit
+```
+
+`x` ("let go") is a reversible soft-archive, not a delete — archived tasks stay recoverable via
+`tend ls --status archived` and on the Someday page.
+
+Interactive mode requires a terminal. Without one, use `--list` or the single-decision form, so an
+agent that runs bare `tend triage` gets a clear error rather than a hang.
+
+## Tests
+
+```bash
+cd cli && uv run pytest
+```

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "tend-cli"
+version = "0.1.0"
+description = "Command-line client for Tend, the conscious todo app."
+requires-python = ">=3.11"
+dependencies = ["httpx>=0.27"]
+
+[project.scripts]
+tend = "tend_cli.cli:main"
+
+[dependency-groups]
+dev = ["pytest>=8.0", "ruff>=0.9"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["tend_cli"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/cli/tend_cli/__init__.py
+++ b/cli/tend_cli/__init__.py
@@ -1,0 +1,3 @@
+"""tend — command-line client for the Tend API."""
+
+__version__ = "0.1.0"

--- a/cli/tend_cli/__main__.py
+++ b/cli/tend_cli/__main__.py
@@ -1,0 +1,4 @@
+from tend_cli.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/tend_cli/cli.py
+++ b/cli/tend_cli/cli.py
@@ -1,0 +1,417 @@
+"""tend — a small CLI over the Tend API.
+
+One artifact, two callers. A human types `tend add "call the dentist #health"`;
+an agent runs the same binary through a shell and passes --json to read
+structured output back. That is why there is no separate machine interface: the
+CLI *is* the integration surface, and it works anywhere a shell does.
+
+Auth is a personal access token (Settings → API tokens). Tokens can create, read
+and modify, but deliberately cannot delete tasks or domains or touch account
+settings — see the PAT policy in backend/tests/test_api_tokens.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from tend_cli.client import DEFAULT_API_URL, TOKEN_PREFIX, TendClient, TendError, write_config
+from tend_cli.grammar import parse_capture
+
+BUCKETS = ("today", "soon", "later", "someday")
+
+# Mirrors the web app's triage keys (components/triage-card.tsx) so the two
+# don't need separate muscle memory.
+TRIAGE_KEYS = {
+    "t": ("confirm", None),
+    "s": ("defer", "soon"),
+    "l": ("defer", "later"),
+    "o": ("defer", "someday"),
+    "d": ("complete", None),
+    "x": ("kill", None),
+}
+
+
+# ── output ────────────────────────────────────────────────────────────────────
+
+
+def _tty() -> bool:
+    return sys.stdout.isatty()
+
+
+def dim(text: str) -> str:
+    return f"\033[2m{text}\033[0m" if _tty() else text
+
+
+def bold(text: str) -> str:
+    return f"\033[1m{text}\033[0m" if _tty() else text
+
+
+def emit_json(payload: Any) -> None:
+    json.dump(payload, sys.stdout, indent=2, default=str)
+    sys.stdout.write("\n")
+
+
+def short_id(task: dict) -> str:
+    return str(task["id"])[:8]
+
+
+def marks(task: dict) -> str:
+    out = "★" if task.get("is_mit") else ""
+    if task.get("important") and task.get("urgent"):
+        out += "!!"
+    elif task.get("important"):
+        out += "!"
+    elif task.get("urgent"):
+        out += "u"
+    return out
+
+
+def format_task(task: dict, *, show_bucket: bool = False) -> str:
+    meta = []
+    if show_bucket:
+        meta.append(str(task["bucket"]))
+    if task.get("domain"):
+        meta.append(str(task["domain"]["name"]))
+    if task.get("size"):
+        meta.append(str(task["size"]).upper())
+    age = task.get("age_days")
+    if isinstance(age, int) and age > 0:
+        meta.append(f"{age}d")
+    if task.get("reschedule_count"):
+        meta.append(f"deferred {task['reschedule_count']}x")
+    if task.get("placement"):
+        meta.append(f"blocked {task['placement'].get('block_start', '')}".strip())
+
+    flag = marks(task)
+    line = f"  {dim(short_id(task))}  {flag + ' ' if flag else ''}{task['text']}"
+    if meta:
+        line += f"  {dim('· ' + ' · '.join(meta))}"
+    return line
+
+
+# ── shared helpers ────────────────────────────────────────────────────────────
+
+
+def resolve_task(client: TendClient, ref: str, tasks: list[dict] | None = None) -> dict:
+    """Find a task by full id, id prefix, or unique text substring.
+
+    UUIDs are unusable by hand, so `tend done a3f2` and `tend done dentist` both
+    work. Ambiguity is always an error rather than a guess — picking the wrong
+    task silently is worse than making the caller be specific.
+    """
+    candidates = client.tasks(status="pending") if tasks is None else tasks
+    lowered = ref.lower()
+
+    for task in candidates:
+        if str(task["id"]) == ref:
+            return task
+
+    def _one(matches: list[dict], how: str) -> dict | None:
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            listing = "\n".join(format_task(t, show_bucket=True) for t in matches[:10])
+            raise TendError(f'"{ref}" matches {len(matches)} tasks by {how}:\n{listing}')
+        return None
+
+    found = _one([t for t in candidates if str(t["id"]).lower().startswith(lowered)], "id")
+    if found:
+        return found
+    found = _one([t for t in candidates if lowered in str(t["text"]).lower()], "text")
+    if found:
+        return found
+
+    raise TendError(f'No pending task matches "{ref}".')
+
+
+# ── commands ──────────────────────────────────────────────────────────────────
+
+
+def cmd_login(args: argparse.Namespace) -> int:
+    token = args.token or input("Paste your Tend API token: ").strip()
+    if not token:
+        raise TendError("No token entered.")
+    if not token.startswith(TOKEN_PREFIX):
+        raise TendError(f"That doesn't look like a Tend token (expected {TOKEN_PREFIX}...).")
+
+    api_url = args.api_url or DEFAULT_API_URL
+    client = TendClient(base_url=api_url.rstrip("/"), token=token)
+    client.state()  # fail now, with a clear message, rather than on first real use
+
+    path = write_config(token, api_url)
+    print(f"Token saved to {path}")
+    return 0
+
+
+def cmd_add(client: TendClient, args: argparse.Namespace) -> int:
+    raw = " ".join(args.text).strip()
+    if not raw:
+        raise TendError("Nothing to add.")
+
+    # Only pay for the domain list when the text could actually bind one.
+    domains = client.domains() if "#" in raw else []
+    parsed = parse_capture(raw, domains)
+    if not parsed.text:
+        raise TendError("That's all tokens and no task text.")
+
+    payload: dict[str, Any] = {
+        "text": parsed.text,
+        # Capture defaults to `soon`, not `today`. Deciding something belongs in
+        # today is what triage is for; a terminal capture shouldn't quietly add
+        # to a day you already committed to. Use -b today (or >today) to mean it.
+        "bucket": args.bucket or parsed.bucket or "soon",
+        "important": parsed.important,
+        "urgent": parsed.urgent,
+    }
+    if parsed.domain_id:
+        payload["domain_id"] = parsed.domain_id
+    if parsed.size:
+        payload["size"] = parsed.size
+
+    task = client.create_task(payload)
+    if args.json:
+        emit_json(task)
+    else:
+        print(f"Added to {bold(str(task['bucket']))}:")
+        print(format_task(task))
+    return 0
+
+
+def cmd_ls(client: TendClient, args: argparse.Namespace) -> int:
+    tasks = client.tasks(bucket=args.bucket, status=args.status or "pending")
+
+    if args.domain:
+        needle = args.domain.lower()
+        tasks = [
+            t
+            for t in tasks
+            if t.get("domain") and str(t["domain"]["name"]).lower().startswith(needle)
+        ]
+
+    if args.json:
+        emit_json(tasks)
+        return 0
+
+    if not tasks:
+        print(dim("Nothing here."))
+        return 0
+
+    by_bucket: dict[str, list[dict]] = {}
+    for task in tasks:
+        by_bucket.setdefault(str(task["bucket"]), []).append(task)
+
+    for bucket in BUCKETS:
+        group = by_bucket.get(bucket)
+        if not group:
+            continue
+        print(f"\n{bold(bucket)}  {dim(f'({len(group)})')}")
+        for task in group:
+            print(format_task(task))
+            for child in task.get("children") or []:
+                print(f"    {dim('└')} {child['text']}")
+    print()
+    return 0
+
+
+def cmd_done(client: TendClient, args: argparse.Namespace) -> int:
+    task = resolve_task(client, args.ref)
+    done = client.complete_task(str(task["id"]))
+    if args.json:
+        emit_json(done)
+    else:
+        print(f"Done: {task['text']}")
+    return 0
+
+
+def cmd_state(client: TendClient, args: argparse.Namespace) -> int:
+    state = client.state()
+    if args.json:
+        emit_json(state)
+        return 0
+
+    buckets = state["buckets"]
+    priority = state["priority"]
+    print(f"\n{bold('Buckets')}")
+    for name in (*BUCKETS, "done"):
+        print(f"  {name:<9} {buckets.get(name, 0)}")
+    print(f"\n{bold('Priority')}  {dim('(pending, top-level)')}")
+    for label, key in (
+        ("important + urgent", "q1_count"),
+        ("important", "q2_count"),
+        ("urgent", "q3_count"),
+        ("neither", "q4_count"),
+    ):
+        print(f"  {label:<20} {priority.get(key, 0)}")
+    print()
+    return 0
+
+
+def cmd_domains(client: TendClient, args: argparse.Namespace) -> int:
+    domains = client.domains()
+    if args.json:
+        emit_json(domains)
+        return 0
+    if not domains:
+        print(dim("No domains yet."))
+        return 0
+    for domain in domains:
+        print(f"  {dim(str(domain['id'])[:8])}  {domain['name']}  {dim(domain['color'])}")
+    return 0
+
+
+def _triage_payload(action: str, bucket: str | None) -> dict:
+    payload: dict[str, Any] = {"action": action}
+    if action == "defer":
+        if bucket is None:
+            raise TendError("defer needs a bucket, e.g. --bucket later")
+        payload["bucket"] = bucket
+    return payload
+
+
+def cmd_triage(client: TendClient, args: argparse.Namespace) -> int:
+    # One decision, no prompting — the shape an agent uses. Resolved against all
+    # pending tasks rather than today's queue, because POST /triage/{id} has no
+    # queue-membership requirement either. A task captured today won't be in the
+    # queue until tomorrow (creation stamps triaged_at), and you should still be
+    # able to name it.
+    if args.ref:
+        if not args.action:
+            raise TendError("Pass an action, e.g. tend triage a3f2 defer --bucket later")
+        task = resolve_task(client, args.ref)
+        result = client.triage(str(task["id"]), _triage_payload(args.action, args.bucket))
+        if args.json:
+            emit_json(result)
+        else:
+            remaining = result.get("remaining")
+            left = dim(f"({remaining} left)") if remaining is not None else ""
+            print(f"{args.action}: {task['text']}  {left}".rstrip())
+        return 0
+
+    queue = client.triage_queue()
+    tasks = queue["tasks"]
+
+    # Read the queue without acting.
+    if args.list or args.json:
+        if args.json:
+            emit_json(queue)
+        elif not tasks:
+            print(dim("Nothing to triage."))
+        else:
+            print(f"\n{bold(f'{len(tasks)} to triage')}")
+            for task in tasks:
+                print(format_task(task, show_bucket=True))
+            print()
+        return 0
+
+    # Human path: walk the queue.
+    if not tasks:
+        print(dim("Nothing to triage. "), end="")
+        print("Your queue is clear.")
+        return 0
+
+    if not sys.stdin.isatty():
+        raise TendError(
+            "Interactive triage needs a terminal. Use --list to read the queue, or\n"
+            "  tend triage <ref> <action> [--bucket ...]  to make one decision."
+        )
+
+    print(
+        f"\n{bold(f'{len(tasks)} to triage')}  {dim('t=today s=soon l=later o=someday d=done x=let go q=quit')}"
+    )
+    for index, task in enumerate(tasks, start=1):
+        print(f"\n{dim(f'[{index}/{len(tasks)}]')} {format_task(task, show_bucket=True).strip()}")
+        while True:
+            try:
+                key = input("  > ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print("\nStopped.")
+                return 0
+            if key in ("q", "quit"):
+                print(dim(f"Stopped with {len(tasks) - index + 1} left."))
+                return 0
+            if key in TRIAGE_KEYS:
+                action, bucket = TRIAGE_KEYS[key]
+                client.triage(str(task["id"]), _triage_payload(action, bucket))
+                break
+            print(dim("  t=today s=soon l=later o=someday d=done x=let go q=quit"))
+
+    print(f"\n{bold('Triage complete.')}\n")
+    return 0
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="tend", description="Tend from the command line.")
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--json", action="store_true", help="emit raw JSON (for scripts and agents)"
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_login = sub.add_parser("login", help="store an API token")
+    p_login.add_argument("token", nargs="?", help="token; prompted for if omitted")
+    p_login.add_argument("--api-url", help=f"API base URL (default {DEFAULT_API_URL})")
+    p_login.set_defaults(needs_client=False, func=cmd_login)
+
+    p_add = sub.add_parser(
+        "add",
+        parents=[common],
+        help="capture a task",
+        description=(
+            "Inline tokens: #domain, ! important, !! important+urgent, u! urgent, "
+            ">today|soon|later|someday, ~s|~m|~l size. Defaults to the soon bucket."
+        ),
+    )
+    p_add.add_argument("text", nargs="+")
+    p_add.add_argument("-b", "--bucket", choices=BUCKETS, help="override the bucket")
+    p_add.set_defaults(func=cmd_add)
+
+    p_ls = sub.add_parser("ls", parents=[common], help="list tasks")
+    p_ls.add_argument("-b", "--bucket", choices=BUCKETS)
+    p_ls.add_argument("-d", "--domain", help="filter by domain name prefix")
+    p_ls.add_argument(
+        "-s", "--status", choices=("pending", "complete", "archived"), help="default pending"
+    )
+    p_ls.set_defaults(func=cmd_ls)
+
+    p_done = sub.add_parser("done", parents=[common], help="complete a task")
+    p_done.add_argument("ref", help="task id, id prefix, or unique text substring")
+    p_done.set_defaults(func=cmd_done)
+
+    p_triage = sub.add_parser("triage", parents=[common], help="walk the triage queue")
+    p_triage.add_argument("ref", nargs="?", help="triage a single task instead of looping")
+    p_triage.add_argument("action", nargs="?", choices=("confirm", "defer", "complete", "kill"))
+    p_triage.add_argument("-b", "--bucket", choices=BUCKETS, help="destination for defer")
+    p_triage.add_argument("--list", action="store_true", help="show the queue without acting")
+    p_triage.set_defaults(func=cmd_triage)
+
+    p_state = sub.add_parser("state", parents=[common], help="counts by bucket and priority")
+    p_state.set_defaults(func=cmd_state)
+
+    p_domains = sub.add_parser("domains", parents=[common], help="list domains")
+    p_domains.set_defaults(func=cmd_domains)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if getattr(args, "needs_client", True):
+            return args.func(TendClient.from_env(), args)
+        return args.func(args)
+    except TendError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/tend_cli/client.py
+++ b/cli/tend_cli/client.py
@@ -1,0 +1,156 @@
+"""HTTP client and credential resolution for the tend CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+# The backend has no public domain of its own — every external request goes
+# through the Next.js proxy, which forwards `tend_pat_` tokens to the backend
+# verbatim. See frontend/src/app/api/[...proxy]/route.ts.
+DEFAULT_API_URL = "https://tendyourgarden.app/api"
+TOKEN_PREFIX = "tend_pat_"
+
+NO_TOKEN_HELP = """No API token found.
+
+Create one in Tend under Settings → API tokens, then either:
+  tend login                       store it in {path}
+  export TEND_TOKEN=tend_pat_...   set it for this shell
+
+Point at a local backend with TEND_API_URL, e.g.
+  export TEND_API_URL=http://localhost:8000"""
+
+
+class TendError(Exception):
+    """A problem worth showing the user verbatim, without a traceback."""
+
+
+def config_path() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base) if base else Path.home() / ".config"
+    return root / "tend" / "config.json"
+
+
+def read_config() -> dict:
+    path = config_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TendError(f"Could not read {path}: {exc}") from exc
+
+
+def write_config(token: str, api_url: str) -> Path:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"token": token, "api_url": api_url}, indent=2) + "\n")
+    path.chmod(0o600)  # it holds a credential
+    return path
+
+
+def _error_message(response: httpx.Response) -> str:
+    """Pull a human message out of a backend error response.
+
+    AppError renders {"code", "message"}; FastAPI's own validation errors render
+    {"detail": ...}. Fall back to the raw body so nothing is ever swallowed.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return f"HTTP {response.status_code}: {response.text.strip()[:200]}"
+
+    if isinstance(body, dict):
+        if "message" in body:
+            return str(body["message"])
+        if "detail" in body:
+            detail = body["detail"]
+            if isinstance(detail, list) and detail:
+                first = detail[0]
+                if isinstance(first, dict):
+                    where = ".".join(str(p) for p in first.get("loc", [])[1:])
+                    msg = first.get("msg", "invalid value")
+                    return f"{where}: {msg}" if where else str(msg)
+            return str(detail)
+    return f"HTTP {response.status_code}: {json.dumps(body)[:200]}"
+
+
+@dataclass
+class TendClient:
+    base_url: str
+    token: str
+
+    @classmethod
+    def from_env(cls) -> TendClient:
+        config = read_config()
+        token = os.environ.get("TEND_TOKEN") or config.get("token")
+        api_url = os.environ.get("TEND_API_URL") or config.get("api_url") or DEFAULT_API_URL
+        if not token:
+            raise TendError(NO_TOKEN_HELP.format(path=config_path()))
+        return cls(base_url=api_url.rstrip("/"), token=token)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict | None = None,
+        json_body: Any = None,
+    ) -> Any:
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        try:
+            response = httpx.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                headers={"Authorization": f"Bearer {self.token}"},
+                timeout=20.0,
+                follow_redirects=True,
+            )
+        except httpx.HTTPError as exc:
+            raise TendError(f"Could not reach {self.base_url}: {exc}") from exc
+
+        if response.status_code == 401:
+            raise TendError(
+                "Token rejected (401). It may have been revoked — check Settings → "
+                "API tokens.\nNote that tokens deliberately cannot delete tasks or "
+                "domains, or touch account settings."
+            )
+        if response.status_code >= 400:
+            raise TendError(_error_message(response))
+        if response.status_code == 204 or not response.content:
+            return None
+        return response.json()
+
+    # Thin wrappers so command code reads as intent, not as HTTP.
+
+    def domains(self) -> list[dict]:
+        return self.request("GET", "/domains") or []
+
+    def tasks(self, **filters: Any) -> list[dict]:
+        params = {k: v for k, v in filters.items() if v is not None}
+        return self.request("GET", "/tasks", params=params) or []
+
+    def create_task(self, payload: dict) -> dict:
+        return self.request("POST", "/tasks", json_body=payload)
+
+    def complete_task(self, task_id: str) -> dict:
+        return self.request("POST", f"/tasks/{task_id}/complete")
+
+    def update_task(self, task_id: str, payload: dict) -> dict:
+        return self.request("PATCH", f"/tasks/{task_id}", json_body=payload)
+
+    def triage_queue(self) -> dict:
+        return self.request("GET", "/triage")
+
+    def triage(self, task_id: str, payload: dict) -> dict:
+        return self.request("POST", f"/triage/{task_id}", json_body=payload)
+
+    def state(self) -> dict:
+        return self.request("GET", "/state")

--- a/cli/tend_cli/grammar.py
+++ b/cli/tend_cli/grammar.py
@@ -1,0 +1,80 @@
+"""Inline capture grammar, ported from frontend/src/lib/parse-capture.ts.
+
+Deliberately a line-by-line port rather than a reimplementation: the web app and
+the CLI must agree on what `buy milk #health !! >soon ~s` means. tests/test_grammar.py
+mirrors the frontend's cases, so a change on either side that isn't mirrored here
+shows up as a test failure rather than as two clients that quietly disagree.
+
+Parsing happens client-side, as it does in the browser. It is an input
+affordance, not a security boundary — whatever it produces still goes through the
+API's own validation (bucket enum, domain ownership, field limits).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+BUCKET_WORDS = ("today", "soon", "later", "someday")
+SIZE_LETTERS = ("s", "m", "l")
+
+
+@dataclass
+class ParsedCapture:
+    text: str = ""
+    domain_id: str | None = None
+    important: bool = False
+    urgent: bool = False
+    bucket: str | None = None
+    size: str | None = None
+
+
+def parse_capture(raw: str, domains: list[dict]) -> ParsedCapture:
+    """Pull inline tokens out of a task string.
+
+        #health       domain, prefix-matched against the user's domain names
+        !             important
+        !!            important + urgent
+        u! / !u       urgent
+        >today|soon|later|someday    bucket
+        ~s | ~m | ~l  size
+
+    Recognized tokens are stripped from the returned text. Unrecognized ones
+    (a `#tag` matching no domain, a `>nonsense`) are left in the text verbatim.
+    """
+    result = ParsedCapture()
+    kept: list[str] = []
+
+    for token in raw.split():
+        lower = token.lower()
+
+        if token == "!":
+            result.important = True
+            continue
+        if token == "!!":
+            result.important = True
+            result.urgent = True
+            continue
+        if token in ("u!", "!u"):
+            result.urgent = True
+            continue
+
+        if token.startswith(">") and lower[1:] in BUCKET_WORDS:
+            result.bucket = lower[1:]
+            continue
+
+        if token.startswith("~") and len(token) == 2 and lower[1:] in SIZE_LETTERS:
+            result.size = lower[1:]
+            continue
+
+        # Binds once — a second #tag is left in the text.
+        if token.startswith("#") and len(token) > 1 and result.domain_id is None:
+            query = lower[1:]
+            match = next((d for d in domains if str(d["name"]).lower().startswith(query)), None)
+            if match is not None:
+                result.domain_id = match["id"]
+                continue
+
+        kept.append(token)
+
+    result.text = " ".join(kept).strip()
+    return result

--- a/cli/tests/test_grammar.py
+++ b/cli/tests/test_grammar.py
@@ -1,0 +1,86 @@
+"""Grammar parity with frontend/src/lib/parse-capture.ts.
+
+If you change the grammar on either side, change it here too. These cases exist
+to make a silent divergence between the web app and the CLI impossible.
+"""
+
+from tend_cli.grammar import parse_capture
+
+DOMAINS = [
+    {"id": "d-work", "name": "Work"},
+    {"id": "d-health", "name": "Health"},
+    {"id": "d-home", "name": "Home"},
+]
+
+
+def test_plain_text_is_untouched():
+    r = parse_capture("call the dentist", DOMAINS)
+    assert r.text == "call the dentist"
+    assert r.domain_id is None
+    assert (r.important, r.urgent) == (False, False)
+    assert r.bucket is None and r.size is None
+
+
+def test_important_and_urgent():
+    assert parse_capture("x !", DOMAINS).important is True
+    assert parse_capture("x !!", DOMAINS).important is True
+    assert parse_capture("x !!", DOMAINS).urgent is True
+
+    for token in ("u!", "!u"):
+        r = parse_capture(f"x {token}", DOMAINS)
+        assert r.urgent is True
+        assert r.important is False, f"{token} sets urgent only"
+
+
+def test_bucket_and_size():
+    r = parse_capture("ship it >soon ~l", DOMAINS)
+    assert (r.text, r.bucket, r.size) == ("ship it", "soon", "l")
+
+
+def test_domain_prefix_match_is_case_insensitive():
+    r = parse_capture("run 5k #hea", DOMAINS)
+    assert (r.text, r.domain_id) == ("run 5k", "d-health")
+    assert parse_capture("run 5k #HEALTH", DOMAINS).domain_id == "d-health"
+
+
+def test_domain_binds_only_once():
+    # "Home" would match #hom, but the domain slot is already taken by #work.
+    r = parse_capture("tidy #work #hom", DOMAINS)
+    assert r.domain_id == "d-work"
+    assert r.text == "tidy #hom"
+
+
+def test_unrecognized_tokens_stay_in_the_text():
+    r = parse_capture("read #nonsense >nowhere ~xl about it", DOMAINS)
+    assert r.text == "read #nonsense >nowhere ~xl about it"
+    assert r.domain_id is None
+    assert r.bucket is None
+    assert r.size is None
+
+
+def test_size_must_be_a_single_letter():
+    # `~m` is a size; `~md` is not, so it survives into the text.
+    assert parse_capture("x ~m", DOMAINS).size == "m"
+    r = parse_capture("x ~md", DOMAINS)
+    assert r.size is None
+    assert r.text == "x ~md"
+
+
+def test_everything_at_once():
+    r = parse_capture("  file the #work brief !! >today ~s  ", DOMAINS)
+    assert r.text == "file the brief"
+    assert r.domain_id == "d-work"
+    assert (r.important, r.urgent) == (True, True)
+    assert (r.bucket, r.size) == ("today", "s")
+
+
+def test_bare_hash_is_not_a_domain():
+    r = parse_capture("count the # of items", DOMAINS)
+    assert r.text == "count the # of items"
+    assert r.domain_id is None
+
+
+def test_no_domains_configured():
+    r = parse_capture("buy milk #health", [])
+    assert r.text == "buy milk #health"
+    assert r.domain_id is None

--- a/cli/tests/test_resolve.py
+++ b/cli/tests/test_resolve.py
@@ -1,0 +1,105 @@
+"""Task reference resolution and error formatting.
+
+Resolving `tend done dentist` to the right task is the CLI's one piece of real
+logic. Getting it wrong means completing the wrong task, so ambiguity must be an
+error rather than a guess.
+"""
+
+import httpx
+import pytest
+
+from tend_cli.cli import resolve_task
+from tend_cli.client import TendError, _error_message
+
+TASKS = [
+    {"id": "aaaa1111-0000-0000-0000-000000000001", "text": "call the plumber", "bucket": "soon"},
+    {
+        "id": "aaaa2222-0000-0000-0000-000000000002",
+        "text": "call the electrician",
+        "bucket": "soon",
+    },
+    {"id": "bbbb3333-0000-0000-0000-000000000003", "text": "file the brief", "bucket": "today"},
+]
+
+
+class StubClient:
+    def __init__(self, tasks=TASKS):
+        self._tasks = tasks
+
+    def tasks(self, **_filters):
+        return self._tasks
+
+
+def test_exact_id_wins():
+    assert resolve_task(StubClient(), TASKS[0]["id"])["text"] == "call the plumber"
+
+
+def test_id_prefix():
+    assert resolve_task(StubClient(), "bbbb3333")["text"] == "file the brief"
+
+
+def test_id_prefix_is_case_insensitive():
+    assert resolve_task(StubClient(), "BBBB3333")["text"] == "file the brief"
+
+
+def test_unique_text_substring():
+    assert resolve_task(StubClient(), "plumb")["text"] == "call the plumber"
+
+
+def test_text_match_is_case_insensitive():
+    assert resolve_task(StubClient(), "BRIEF")["text"] == "file the brief"
+
+
+def test_ambiguous_text_raises_and_lists_candidates():
+    with pytest.raises(TendError) as exc:
+        resolve_task(StubClient(), "call")
+    message = str(exc.value)
+    assert "matches 2 tasks" in message
+    assert "plumber" in message and "electrician" in message
+
+
+def test_no_match_raises():
+    with pytest.raises(TendError, match="No pending task matches"):
+        resolve_task(StubClient(), "nonexistent")
+
+
+def test_id_match_beats_text_match():
+    """An id prefix is unambiguous intent; it should never be shadowed by text."""
+    tasks = [
+        {"id": "cafe0000-0000-0000-0000-000000000001", "text": "one", "bucket": "soon"},
+        {
+            "id": "dddd0000-0000-0000-0000-000000000002",
+            "text": "grind cafe beans",
+            "bucket": "soon",
+        },
+    ]
+    assert resolve_task(StubClient(tasks), "cafe")["text"] == "one"
+
+
+def test_explicit_task_list_is_used_without_fetching():
+    class Exploding:
+        def tasks(self, **_filters):
+            raise AssertionError("should not fetch when tasks are supplied")
+
+    assert resolve_task(Exploding(), "brief", TASKS)["text"] == "file the brief"
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"code": "not_found", "message": "Task not found"}, "Task not found"),
+        ({"detail": "plain detail"}, "plain detail"),
+        (
+            {"detail": [{"loc": ["body", "bucket"], "msg": "invalid bucket"}]},
+            "bucket: invalid bucket",
+        ),
+    ],
+)
+def test_error_message_extraction(payload, expected):
+    response = httpx.Response(422, json=payload)
+    assert _error_message(response) == expected
+
+
+def test_error_message_falls_back_to_raw_body():
+    response = httpx.Response(502, text="upstream exploded")
+    assert "upstream exploded" in _error_message(response)

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -1,0 +1,189 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
+name = "tend-cli"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "httpx", specifier = ">=0.27" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.9" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/frontend/src/app/api/[...proxy]/route.ts
+++ b/frontend/src/app/api/[...proxy]/route.ts
@@ -7,11 +7,6 @@ async function handler(
   { params }: { params: Promise<{ proxy: string[] }> }
 ) {
   try {
-    const session = await auth();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const backendUrl = process.env.BACKEND_URL;
     if (!backendUrl) {
       return NextResponse.json(
@@ -20,7 +15,30 @@ async function handler(
       );
     }
 
-    const backendToken = await createBackendToken(session.user.id);
+    // Two ways in. A browser session gets a freshly minted 60s proxy JWT. An
+    // external client (the tend CLI, Plot, an agent) presents a personal access
+    // token, which we forward verbatim for the backend to validate against its
+    // token hashes. The backend has no public domain, so this proxy is the only
+    // door — without the PAT branch, tokens would be unreachable in production.
+    //
+    // ONLY the tend_pat_ prefix is passed through. Any other Authorization value
+    // is ignored and replaced by a JWT we mint ourselves, so a caller can never
+    // smuggle in a self-supplied proxy token. Which endpoints a PAT may actually
+    // reach is decided by the backend (get_user_id_allow_pat), not here.
+    const incomingAuth = req.headers.get("authorization") ?? "";
+    const isPat = incomingAuth.startsWith("Bearer tend_pat_");
+
+    let backendToken: string;
+    if (isPat) {
+      backendToken = incomingAuth.slice("Bearer ".length);
+    } else {
+      const session = await auth();
+      if (!session?.user?.id) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
+      backendToken = await createBackendToken(session.user.id);
+    }
+
     const { proxy } = await params;
     const path = proxy.join("/");
     const base = backendUrl.endsWith("/") ? backendUrl : `${backendUrl}/`;


### PR DESCRIPTION
Closes #219.

## The problem

#218 shipped personal access tokens, but two things left them unusable:

1. **Only six endpoints accepted one.** `GET /state` (what PRD §17.4 calls "the agent's working memory") and `POST /triage/{id}` (the most Tend-specific verb in the API) both rejected tokens. A token holder could *read* the triage queue but not *triage*, failing the §17.1 parity test on the app's core action.
2. **There was no production door at all.** The backend has no public domain, and `[...proxy]` 401s any request without a NextAuth session — then discards the incoming Authorization header anyway. Confirmed against prod: a PAT gets a flat 401.

## What changed

**PAT coverage.** `get_user_id_allow_pat` now covers `/state`, the triage routes, `/domains` (read/create/rename), and the task modify routes. The policy is stated once and enforced as data:

> **A token can create, read, and modify. It cannot destroy.**

A token sits in plaintext in config files and agent settings, so it's a more exposed credential than a browser session. `DELETE /tasks/{id}`, `DELETE /domains/{id}`, `/me`, `/billing`, and **all of `/api-tokens`** (no minting more tokens) stay proxy-JWT only. Everything reversible is deliberately open, because per §17.2 the question of *whether* to act belongs in the agent's prompt, not the API.

`PAT_MATRIX` in `test_api_tokens.py` parametrizes that route by route. Add a route → add a row. That's the guard against this surface drifting UI-only again.

**Triage `kill` archives instead of deleting.** It now calls a new `task_service.archive_task` that mirrors `complete_task`'s cascade. This closed a divergence rather than adding a mechanism: `triage-card.tsx` already intercepted "let go" and PATCHed `status=archived` so undo could restore it, leaving the backend's hard-delete branch reachable only by direct API callers. With the endpoint uniformly reversible, it could be opened to tokens with no auth-mode plumbing. Hard delete stays at `DELETE /tasks/{id}`, session-only.

**Proxy.** Forwards `Bearer tend_pat_*` verbatim; still mints a fresh 60s JWT for session callers. Only that prefix passes through, so a caller can never supply its own proxy token.

**The `tend` CLI** (`cli/`, `uv tool install ./cli`): `add`, `ls`, `done`, `triage`, `state`, `domains`. Read commands take `--json`, so one artifact serves both a human at a terminal and an agent through a shell.

```
tend add "file the appellate brief #work !! ~s"
tend ls -b today
tend done dentist
tend triage                          # interactive, same keys as the web app
tend triage a3f2 defer --bucket later
```

## Why a CLI and not an MCP server

MCP is a wrapper over an API that already exists. A CLI reaches every agent harness, cron job, and shell script without a protocol, is allowlistable as `Bash(tend:*)`, and demos as a terminal recording. MCP earns its keep only for clients with no shell (Claude Desktop, mobile), and by then it's a thin wrapper over this same client — so nothing here is wasted by deferring it.

## Decisions worth a second opinion

- **`tend add` defaults to `soon`, not `today`** (the backend default). Deciding something belongs in today is what triage is for; a terminal capture shouldn't quietly add to a day already committed to. One line to flip if you disagree.
- **`kill` semantics changed** on an existing endpoint. No client depended on the old behavior (the frontend hasn't sent `action: "kill"` in a long time), and the new behavior is strictly safer, but it is a real API change.
- **Fuzzy refs.** `tend done dentist` resolves by id, id prefix, or unique text substring. Ambiguity always errors and lists candidates. A short unique substring can still match something you didn't picture, though completion is reversible.

## Verification

Backend: 229 tests pass, ruff clean. Frontend: tsc + eslint clean. CLI: 23 tests, now wired into CI (they need no database, unlike the backend suite).

Beyond CI, exercised against a real local stack:

- capture with the full token grammar, including unrecognized tokens surviving into the text verbatim
- ref resolution and its ambiguity errors
- `defer` incrementing `reschedule_count`, and `kill` leaving the task recoverable under `--status archived`
- interactive triage driven through a pty (valid key advances, invalid key reprompts)
- the whole chain CLI → Next proxy → FastAPI with a real token, plus confirmation that `/api-tokens`, `/me`, and a self-minted JWT are all still rejected through the proxy

## Follow-ups not in this PR

- #213–#217 appear to have shipped in #218 but never auto-closed; they need a verify-and-close sweep.
- A `~/.claude/skills/tend/` skill wrapping this CLI is written and live locally (it's outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
